### PR TITLE
docs: add AGENTS.md with CLAUDE.md symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .temp/
 .DS_Store
 .env*
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+## Contributing
+
+Before opening an issue or pull request, read `CONTRIBUTING.md` and follow its guidance.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -4583,6 +4583,7 @@ export interface components {
             track_activity_query_size?: string;
             max_connections?: number;
             max_locks_per_transaction?: number;
+            max_logical_replication_workers?: number;
             max_parallel_maintenance_workers?: number;
             max_parallel_workers?: number;
             max_parallel_workers_per_gather?: number;
@@ -4590,6 +4591,7 @@ export interface components {
             max_slot_wal_keep_size?: string;
             max_standby_archive_delay?: string;
             max_standby_streaming_delay?: string;
+            max_sync_workers_per_subscription?: number;
             max_wal_size?: string;
             max_wal_senders?: number;
             max_worker_processes?: number;
@@ -4633,6 +4635,7 @@ export interface components {
             track_activity_query_size?: string;
             max_connections?: number;
             max_locks_per_transaction?: number;
+            max_logical_replication_workers?: number;
             max_parallel_maintenance_workers?: number;
             max_parallel_workers?: number;
             max_parallel_workers_per_gather?: number;
@@ -4640,6 +4643,7 @@ export interface components {
             max_slot_wal_keep_size?: string;
             max_standby_archive_delay?: string;
             max_standby_streaming_delay?: string;
+            max_sync_workers_per_subscription?: number;
             max_wal_size?: string;
             max_wal_senders?: number;
             max_worker_processes?: number;


### PR DESCRIPTION
Add AGENTS.md pointing contributors to CONTRIBUTING.md, with CLAUDE.md as a symlink.

Also ran `pnpm generate:management-api-types` to generate the mgmt-api types.

Close [AI-877]( https://linear.app/supabase/issue/AI-877/add-agentsmd-guidance-to-review-contributingmd-first)