### PR TITLE
fix: select query_logs dialect via logsDialect

### DIFF
--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -253,6 +253,7 @@ export function createSupabaseApiPlatform(
   };
 
   const debugging: DebuggingOperations = {
+    logsDialect: 'clickhouse',
     async getLogs(projectId: string, options: GetLogsOptions) {
       const { service, iso_timestamp_start, iso_timestamp_end } =
         getLogsOptionsSchema.parse(options);

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -217,7 +217,20 @@ export type EdgeFunctionsOperations = {
   ): Promise<Omit<EdgeFunction, 'files'>>;
 };
 
+/**
+ * SQL dialect that a platform's logs endpoint speaks. Selects the
+ * dialect-appropriate `query_logs` description and `sql` parameter hint so a
+ * single tool can roll out across environments that back logs with different
+ * engines (hosted ClickHouse vs. self-hosted/CLI BigQuery).
+ */
+export type LogsDialect = 'clickhouse' | 'bigquery';
+
 export type DebuggingOperations = {
+  /**
+   * SQL dialect accepted by `queryLogs`. Defaults to `'clickhouse'` when unset,
+   * preserving the behavior of platforms that predate this field.
+   */
+  logsDialect?: LogsDialect;
   getLogs(projectId: string, options: GetLogsOptions): Promise<unknown>;
   queryLogs?(projectId: string, options: QueryLogsOptions): Promise<unknown>;
   getSecurityAdvisors(projectId: string): Promise<unknown>;

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4052,6 +4052,79 @@ describe('feature groups', () => {
     expect(toolNames).toEqual(['get_logs', 'get_advisors']);
   });
 
+  test('query_logs advertises the ClickHouse dialect by default', async () => {
+    const { client } = await setup({ features: ['debugging'] });
+
+    const { tools } = await client.listTools();
+    const queryLogs = tools.find((tool) => tool.name === 'query_logs');
+    const sqlDescription = (queryLogs?.inputSchema.properties as any)?.sql
+      ?.description as string | undefined;
+
+    expect(queryLogs?.description).toContain('ClickHouse');
+    expect(sqlDescription).toContain("log_attributes['<key>']");
+  });
+
+  test('query_logs advertises the BigQuery dialect when the platform declares it', async () => {
+    const platform: SupabasePlatform = {
+      debugging: {
+        logsDialect: 'bigquery',
+        getLogs() {
+          throw new Error('Not implemented');
+        },
+        queryLogs() {
+          throw new Error('Not implemented');
+        },
+        getSecurityAdvisors() {
+          throw new Error('Not implemented');
+        },
+        getPerformanceAdvisors() {
+          throw new Error('Not implemented');
+        },
+      },
+    };
+
+    const { client } = await setup({ platform, features: ['debugging'] });
+
+    const { tools } = await client.listTools();
+    const queryLogs = tools.find((tool) => tool.name === 'query_logs');
+    const sqlDescription = (queryLogs?.inputSchema.properties as any)?.sql
+      ?.description as string | undefined;
+
+    expect(queryLogs?.description).toContain('BigQuery');
+    expect(queryLogs?.description).not.toContain('ClickHouse');
+    expect(sqlDescription).toContain('unnest(metadata)');
+    expect(sqlDescription).not.toContain('log_attributes');
+  });
+
+  test('query_logs falls back to the ClickHouse dialect when logsDialect is unset', async () => {
+    const platform: SupabasePlatform = {
+      debugging: {
+        getLogs() {
+          throw new Error('Not implemented');
+        },
+        queryLogs() {
+          throw new Error('Not implemented');
+        },
+        getSecurityAdvisors() {
+          throw new Error('Not implemented');
+        },
+        getPerformanceAdvisors() {
+          throw new Error('Not implemented');
+        },
+      },
+    };
+
+    const { client } = await setup({ platform, features: ['debugging'] });
+
+    const { tools } = await client.listTools();
+    const queryLogs = tools.find((tool) => tool.name === 'query_logs');
+    const sqlDescription = (queryLogs?.inputSchema.properties as any)?.sql
+      ?.description as string | undefined;
+
+    expect(queryLogs?.description).toContain('ClickHouse');
+    expect(sqlDescription).toContain("log_attributes['<key>']");
+  });
+
   test('development tools', async () => {
     const { client } = await setup({
       features: ['development'],

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4094,6 +4094,10 @@ describe('feature groups', () => {
     expect(queryLogs?.description).not.toContain('ClickHouse');
     expect(sqlDescription).toContain('unnest(metadata)');
     expect(sqlDescription).not.toContain('log_attributes');
+    // Self-hosted BigQuery (Logflare) does not serve these sources, so the hint
+    // must not advertise them (see apps/studio/lib/api/self-hosted/logs.ts).
+    expect(sqlDescription).not.toContain('function_logs');
+    expect(sqlDescription).not.toContain('workflow_run_logs');
   });
 
   test('query_logs falls back to the ClickHouse dialect when logsDialect is unset', async () => {

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -58,27 +58,48 @@ function buildQueryLogsInputSchema(sqlDescription: string) {
 }
 
 /**
- * The `query_logs` tool copy, keyed by the dialect its logs endpoint speaks.
- * The whole description and `sql` param hint are swapped per dialect — no
- * conditional prose the model has to reason about. Precomputed at module level
- * because zod schemas with `.describe()` auto-register in the global registry,
- * so rebuilding them per `getDebuggingTools` call would grow it unboundedly.
+ * Builds the `query_logs` copy for one dialect from the shared wording, so only
+ * the two parts that genuinely differ per dialect are supplied: the SQL dialect
+ * `name` and the `schemaHint` describing how that backend exposes logs.
+ */
+function buildQueryLogsCopy({
+  name,
+  schemaHint,
+}: {
+  name: string;
+  schemaHint: string;
+}) {
+  return {
+    description: `Runs a custom read-only ${name} SQL query against a Supabase project's unified logs stream, for filtering, aggregating, or joining across log fields more precisely than a simple per-service log dump. When the user asks about a specific time range, always pass iso_timestamp_start and iso_timestamp_end to match it; otherwise the query defaults to the last 24 hours and will return results from a wider window than intended. The window can be up to 24 hours. Do not poll this tool in a loop.`,
+    parameters: buildQueryLogsInputSchema(
+      `A read-only ${name} SQL query to run against the project's unified logs stream. ${schemaHint}`
+    ),
+  };
+}
+
+/**
+ * The `query_logs` tool copy, keyed by the dialect its logs endpoint speaks. The
+ * whole description and `sql` param hint are swapped per dialect — no conditional
+ * prose the model has to reason about. `schemaHint` mirrors how each backend
+ * exposes logs: hosted ClickHouse serves a single `logs` table filtered by
+ * `source`, while self-hosted BigQuery (Logflare) serves one source table per
+ * service with fields nested under `metadata` (see
+ * `apps/studio/lib/api/self-hosted/logs.ts` in `supabase`). Precomputed at module
+ * level because zod schemas with `.describe()` auto-register in the global
+ * registry, so rebuilding them per `getDebuggingTools` call would grow it
+ * unboundedly.
  */
 const queryLogsByDialect = {
-  clickhouse: {
-    description:
-      "Runs a custom read-only ClickHouse SQL query against a Supabase project's unified logs stream, for filtering, aggregating, or joining across log fields more precisely than a simple per-service log dump. When the user asks about a specific time range, always pass iso_timestamp_start and iso_timestamp_end to match it; otherwise the query defaults to the last 24 hours and will return results from a wider window than intended. The window can be up to 24 hours. Do not poll this tool in a loop.",
-    parameters: buildQueryLogsInputSchema(
-      "A read-only ClickHouse SQL query to run against the project's unified logs stream. Logs are exposed through a `logs` table; filter by `source` (e.g. 'edge_logs', 'postgres_logs', 'function_edge_logs', 'function_logs', 'auth_logs', 'storage_logs', 'realtime_logs', 'workflow_run_logs') and read nested fields via `log_attributes['<key>']`."
-    ),
-  },
-  bigquery: {
-    description:
-      "Runs a custom read-only BigQuery SQL query against a Supabase project's logs, for filtering, aggregating, or joining across log fields more precisely than a simple per-service log dump. When the user asks about a specific time range, always pass iso_timestamp_start and iso_timestamp_end to match it; otherwise the query defaults to the last 24 hours and will return results from a wider window than intended. The window can be up to 24 hours. Do not poll this tool in a loop.",
-    parameters: buildQueryLogsInputSchema(
-      "A read-only BigQuery SQL query to run against the project's logs. Each log service is exposed as its own source (e.g. 'edge_logs', 'postgres_logs', 'function_edge_logs', 'function_logs', 'auth_logs', 'storage_logs', 'realtime_logs'); read nested fields by cross joining `unnest(metadata) as m` and selecting `m.<key>`."
-    ),
-  },
+  clickhouse: buildQueryLogsCopy({
+    name: 'ClickHouse',
+    schemaHint:
+      "Logs are exposed through a `logs` table; filter by `source` (e.g. 'edge_logs', 'postgres_logs', 'function_edge_logs', 'function_logs', 'auth_logs', 'storage_logs', 'realtime_logs', 'workflow_run_logs') and read nested fields via `log_attributes['<key>']`.",
+  }),
+  bigquery: buildQueryLogsCopy({
+    name: 'BigQuery',
+    schemaHint:
+      "Each service has its own source table (e.g. 'edge_logs', 'postgres_logs', 'function_edge_logs', 'auth_logs', 'storage_logs', 'realtime_logs'); nested fields live under `metadata`, read via `cross join unnest(metadata) as m` and then `m.<field>` (unnest further for nested structs such as `m.request` or `m.parsed`).",
+  }),
 } as const satisfies Record<
   LogsDialect,
   {

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -59,20 +59,23 @@ function buildQueryLogsInputSchema(sqlDescription: string) {
 
 /**
  * Builds the `query_logs` copy for one dialect from the shared wording, so only
- * the two parts that genuinely differ per dialect are supplied: the SQL dialect
- * `name` and the `schemaHint` describing how that backend exposes logs.
+ * the parts that genuinely differ per dialect are supplied: the SQL dialect
+ * `name`, the `logsNoun` for how logs are exposed (ClickHouse serves a single
+ * unified stream, BigQuery serves per-service tables), and the `schemaHint`.
  */
 function buildQueryLogsCopy({
   name,
+  logsNoun,
   schemaHint,
 }: {
   name: string;
+  logsNoun: string;
   schemaHint: string;
 }) {
   return {
-    description: `Runs a custom read-only ${name} SQL query against a Supabase project's unified logs stream, for filtering, aggregating, or joining across log fields more precisely than a simple per-service log dump. When the user asks about a specific time range, always pass iso_timestamp_start and iso_timestamp_end to match it; otherwise the query defaults to the last 24 hours and will return results from a wider window than intended. The window can be up to 24 hours. Do not poll this tool in a loop.`,
+    description: `Runs a custom read-only ${name} SQL query against a Supabase project's ${logsNoun}, for filtering, aggregating, or joining across log fields more precisely than a simple per-service log dump. When the user asks about a specific time range, always pass iso_timestamp_start and iso_timestamp_end to match it; otherwise the query defaults to the last 24 hours and will return results from a wider window than intended. The window can be up to 24 hours. Do not poll this tool in a loop.`,
     parameters: buildQueryLogsInputSchema(
-      `A read-only ${name} SQL query to run against the project's unified logs stream. ${schemaHint}`
+      `A read-only ${name} SQL query to run against the project's ${logsNoun}. ${schemaHint}`
     ),
   };
 }
@@ -92,13 +95,15 @@ function buildQueryLogsCopy({
 const queryLogsByDialect = {
   clickhouse: buildQueryLogsCopy({
     name: 'ClickHouse',
+    logsNoun: 'unified logs stream',
     schemaHint:
-      "Logs are exposed through a `logs` table; filter by `source` (e.g. 'edge_logs', 'postgres_logs', 'function_edge_logs', 'function_logs', 'auth_logs', 'storage_logs', 'realtime_logs', 'workflow_run_logs') and read nested fields via `log_attributes['<key>']`.",
+      "Logs are exposed through a `logs` table; filter by `source` (common values include 'edge_logs', 'postgres_logs', and 'function_edge_logs', but this list is not exhaustive — run `select distinct source from logs` to discover the sources available for this project) and read nested fields via `log_attributes['<key>']`.",
   }),
   bigquery: buildQueryLogsCopy({
     name: 'BigQuery',
+    logsNoun: 'logs',
     schemaHint:
-      "Each service has its own source table (e.g. 'edge_logs', 'postgres_logs', 'function_edge_logs', 'auth_logs', 'storage_logs', 'realtime_logs'); nested fields live under `metadata`, read via `cross join unnest(metadata) as m` and then `m.<field>` (unnest further for nested structs such as `m.request` or `m.parsed`).",
+      "Each service has its own source table (common ones include 'edge_logs', 'postgres_logs', and 'function_edge_logs', but the set is not exhaustive — other per-service tables, e.g. Data API and pooler logs, also exist); read nested fields by cross joining `unnest(metadata) as m` and then `m.<field>` (unnest further for nested structs such as `m.request` or `m.parsed`).",
   }),
 } as const satisfies Record<
   LogsDialect,

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -2,12 +2,15 @@ import { z } from 'zod/v4';
 import {
   logsServiceSchema,
   type DebuggingOperations,
+  type LogsDialect,
 } from '../platform/types.js';
 import {
   injectableTool,
   type ToolDefs,
   wrapWithUntrustedDataBoundary,
 } from './util.js';
+
+const DEFAULT_LOGS_DIALECT: LogsDialect = 'clickhouse';
 
 type DebuggingToolsOptions = {
   debugging: DebuggingOperations;
@@ -35,27 +38,54 @@ const getLogsOutputSchema = z.object({
   result: z.unknown(),
 });
 
-const queryLogsInputSchema = z.object({
-  project_id: z.string(),
-  sql: z
-    .string()
-    .min(1)
-    .describe(
+function buildQueryLogsInputSchema(sqlDescription: string) {
+  return z.object({
+    project_id: z.string(),
+    sql: z.string().min(1).describe(sqlDescription),
+    iso_timestamp_start: z.iso
+      .datetime({ offset: true })
+      .optional()
+      .describe(
+        'The start of the log window as an ISO 8601 timestamp, including a UTC "Z" suffix or explicit offset. Defaults to 24 hours before the end of the window. The API caps the requested range at 24 hours.'
+      ),
+    iso_timestamp_end: z.iso
+      .datetime({ offset: true })
+      .optional()
+      .describe(
+        'The end of the log window as an ISO 8601 timestamp, including a UTC "Z" suffix or explicit offset. Defaults to the current time. The API caps the requested range at 24 hours.'
+      ),
+  });
+}
+
+/**
+ * The `query_logs` tool copy, keyed by the dialect its logs endpoint speaks.
+ * The whole description and `sql` param hint are swapped per dialect — no
+ * conditional prose the model has to reason about. Precomputed at module level
+ * because zod schemas with `.describe()` auto-register in the global registry,
+ * so rebuilding them per `getDebuggingTools` call would grow it unboundedly.
+ */
+const queryLogsByDialect = {
+  clickhouse: {
+    description:
+      "Runs a custom read-only ClickHouse SQL query against a Supabase project's unified logs stream, for filtering, aggregating, or joining across log fields more precisely than a simple per-service log dump. When the user asks about a specific time range, always pass iso_timestamp_start and iso_timestamp_end to match it; otherwise the query defaults to the last 24 hours and will return results from a wider window than intended. The window can be up to 24 hours. Do not poll this tool in a loop.",
+    parameters: buildQueryLogsInputSchema(
       "A read-only ClickHouse SQL query to run against the project's unified logs stream. Logs are exposed through a `logs` table; filter by `source` (e.g. 'edge_logs', 'postgres_logs', 'function_edge_logs', 'function_logs', 'auth_logs', 'storage_logs', 'realtime_logs', 'workflow_run_logs') and read nested fields via `log_attributes['<key>']`."
     ),
-  iso_timestamp_start: z.iso
-    .datetime({ offset: true })
-    .optional()
-    .describe(
-      'The start of the log window as an ISO 8601 timestamp, including a UTC "Z" suffix or explicit offset. Defaults to 24 hours before the end of the window. The API caps the requested range at 24 hours.'
+  },
+  bigquery: {
+    description:
+      "Runs a custom read-only BigQuery SQL query against a Supabase project's logs, for filtering, aggregating, or joining across log fields more precisely than a simple per-service log dump. When the user asks about a specific time range, always pass iso_timestamp_start and iso_timestamp_end to match it; otherwise the query defaults to the last 24 hours and will return results from a wider window than intended. The window can be up to 24 hours. Do not poll this tool in a loop.",
+    parameters: buildQueryLogsInputSchema(
+      "A read-only BigQuery SQL query to run against the project's logs. Each log service is exposed as its own source (e.g. 'edge_logs', 'postgres_logs', 'function_edge_logs', 'function_logs', 'auth_logs', 'storage_logs', 'realtime_logs'); read nested fields by cross joining `unnest(metadata) as m` and selecting `m.<key>`."
     ),
-  iso_timestamp_end: z.iso
-    .datetime({ offset: true })
-    .optional()
-    .describe(
-      'The end of the log window as an ISO 8601 timestamp, including a UTC "Z" suffix or explicit offset. Defaults to the current time. The API caps the requested range at 24 hours.'
-    ),
-});
+  },
+} as const satisfies Record<
+  LogsDialect,
+  {
+    description: string;
+    parameters: ReturnType<typeof buildQueryLogsInputSchema>;
+  }
+>;
 
 const queryLogsOutputSchema = z.object({
   result: z.unknown(),
@@ -87,9 +117,8 @@ export const debuggingToolDefs = {
     },
   },
   query_logs: {
-    description:
-      "Runs a custom read-only ClickHouse SQL query against a Supabase project's unified logs stream, for filtering, aggregating, or joining across log fields more precisely than a simple per-service log dump. When the user asks about a specific time range, always pass iso_timestamp_start and iso_timestamp_end to match it; otherwise the query defaults to the last 24 hours and will return results from a wider window than intended. The window can be up to 24 hours. Do not poll this tool in a loop.",
-    parameters: queryLogsInputSchema,
+    description: queryLogsByDialect[DEFAULT_LOGS_DIALECT].description,
+    parameters: queryLogsByDialect[DEFAULT_LOGS_DIALECT].parameters,
     outputSchema: queryLogsOutputSchema,
     annotations: {
       title: 'Query project logs',
@@ -156,6 +185,7 @@ export function getDebuggingTools({
 }: DebuggingToolsOptions) {
   const project_id = projectId;
   const { queryLogs } = debugging;
+  const logsDialect = debugging.logsDialect ?? DEFAULT_LOGS_DIALECT;
 
   return {
     get_logs: injectableTool({
@@ -180,6 +210,10 @@ export function getDebuggingTools({
     ...(queryLogs && {
       query_logs: injectableTool({
         ...debuggingToolDefs.query_logs,
+        // Pick the whole description/param hint for the platform's dialect
+        // rather than branching on the environment inside the prose.
+        description: queryLogsByDialect[logsDialect].description,
+        parameters: queryLogsByDialect[logsDialect].parameters,
         inject: { project_id },
         execute: async ({
           project_id,


### PR DESCRIPTION
Adds an optional `logsDialect` (`'clickhouse' | 'bigquery'`) to `DebuggingOperations` so each platform declares which SQL its logs endpoint speaks. `query_logs` then picks its whole dialect-appropriate description and `sql` param hint from a single lookup table, instead of hardcoding ClickHouse copy — no environment-conditional prose the model has to reason about. Defaults to `'clickhouse'` when unset, so existing platform implementers are unaffected.

Implements [Matt's `logsDialect` suggestion](https://supabase.slack.com/archives/C08N7894QTG/p1784660787397029?thread_ts=1784624411.491679&cid=C08N7894QTG) raised in the #333 review.

**Why**: it lets `query_logs` roll out across every environment without env-specific branching. Hosted stays ClickHouse; self-hosted/CLI can keep its BigQuery-backed logs endpoint and declare `logsDialect: 'bigquery'`. This unblocks shipping the MCP server to self-hosted (studio) regardless of whether it's on BigQuery or ClickHouse, rather than holding the studio image back until self-hosted moves to ClickHouse.

> [!NOTE]
> The comment sketched "reuse the `get_logs` description for `bigquery`" — I instead give `query_logs` a proper BigQuery-dialect description, since `get_logs` describes a `service` param while `query_logs` takes `sql`. The BigQuery `sql` hint mirrors the canonical Logflare self-hosted schema (`cross join unnest(metadata)`); worth confirming when studio wires up the platform.

Refs AI-1046