### PR TITLE
chore: add dependency firewall to publish

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -27,6 +27,17 @@ jobs:
           install: true
           cache: true
 
+      - name: Configure DepthFirst dependency firewall
+        if: ${{ secrets.DF_FIREWALL_TOKEN != '' }}
+        shell: bash
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
+        run: |
+          {
+            echo "registry=https://firewall.depthfirst.com/npm/"
+            echo "//firewall.depthfirst.com/npm/:_authToken=${DF_FIREWALL_TOKEN}"
+          } >> ~/.npmrc
+
       - name: Install dependencies
         run: pnpm install --ignore-scripts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,17 @@ jobs:
           install: true
           cache: true
 
+      - name: Configure DepthFirst dependency firewall
+        if: ${{ secrets.DF_FIREWALL_TOKEN != '' }}
+        shell: bash
+        env:
+          DF_FIREWALL_TOKEN: ${{ secrets.DF_FIREWALL_TOKEN }}
+        run: |
+          {
+            echo "registry=https://firewall.depthfirst.com/npm/"
+            echo "//firewall.depthfirst.com/npm/:_authToken=${DF_FIREWALL_TOKEN}"
+          } >> ~/.npmrc
+
       - name: Install dependencies
         if: ${{ steps.release.outputs.releases_created || inputs.force_publish == true }}
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI hardening

Workflows that lead to a package being published (npm) should fetch dependencies via the dependency firewall.

- [x] `DF_FIREWALL_TOKEN` added to repo secrets
- [x]  Policy in evaluation mode
