### PR TITLE
Add context-cost badge (5,013 tokens, reproducibly measured)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Supabase MCP Server
 
 [![MCP Registry Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fregistry.modelcontextprotocol.io%2Fv0.1%2Fservers%2Fcom.supabase%252Fmcp%2Fversions%2Flatest&query=%24.server.version&label=MCP%20Registry&logo=modelcontextprotocol)](https://registry.modelcontextprotocol.io/?q=com.supabase%2Fmcp)
+[![context cost](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fathakur3%2Fmcp-context-cost%2Fmain%2Fbadges%2Fsupabase.json)](https://athakur3.github.io/mcp-context-cost/METHODOLOGY)
 
 > Connect your Supabase projects to Cursor, Claude, Windsurf, and other AI assistants.
 


### PR DESCRIPTION
One line: a shields.io badge showing what the Supabase MCP server's tool schemas cost in context tokens — currently **5,013 tokens across 29 tools** (largest: `query_logs` at 800), measured 2026-08-16 at default configuration. Median across the 57 popular MCP servers we measured: 2,636.

Neutral transparency, not a judgment — 29 tools covering a full platform lands where you'd expect, and the per-tool breakdown in [results/supabase/measurement.json](https://github.com/athakur3/mcp-context-cost/blob/main/results/supabase/measurement.json) makes trimming actionable if you ever want it. The badge JSON refreshes weekly; the number links to a reproducible methodology (raw `tools/list` capture + pinned `o200k_base` tokenizer, re-derivable in five lines).

If you'd rather not carry this, close freely — no hard feelings. To own the number in your own CI instead: sd2k/mcp-tokens-action (badge support proposed in sd2k/mcp-tokens-action#5).