### PR TITLE
fix: expose cost tools in project-scoped mode so create_branch is callable

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -5586,13 +5586,14 @@ describe('project scoped tools', () => {
 
     const result = await client.listTools();
 
+    // `get_cost` and `confirm_cost` are not listed here: they stay
+    // available in project scope (when branching is enabled) so that
+    // `create_branch` remains callable.
     const accountLevelToolNames = [
       'list_organizations',
       'get_organization',
       'list_projects',
       'get_project',
-      'get_cost',
-      'confirm_cost',
       'create_project',
       'pause_project',
       'restore_project',
@@ -5606,6 +5607,184 @@ describe('project scoped tools', () => {
         `tool ${accountLevelToolName} should not be available in project scope`
       ).not.toContain(accountLevelToolName);
     }
+  });
+
+  test('cost tools are available when branching is enabled', async () => {
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+
+    const { client } = await setup({ projectId: project.id });
+
+    const result = await client.listTools();
+    const toolNames = result.tools.map((tool) => tool.name);
+
+    expect(toolNames).toContain('get_cost');
+    expect(toolNames).toContain('confirm_cost');
+  });
+
+  test('cost tools are not available when branching is disabled', async () => {
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+
+    const { client } = await setup({
+      projectId: project.id,
+      features: ['database', 'docs'],
+    });
+
+    const result = await client.listTools();
+    const toolNames = result.tools.map((tool) => tool.name);
+
+    expect(toolNames).not.toContain('get_cost');
+    expect(toolNames).not.toContain('confirm_cost');
+  });
+
+  test('create branch using the scoped cost tools', async () => {
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const { callTool } = await setup({ projectId: project.id });
+
+    const cost = await callTool({
+      name: 'get_cost',
+      arguments: {
+        type: 'branch',
+        organization_id: org.id,
+      },
+    });
+
+    expect(cost).toEqual({
+      type: 'branch',
+      recurrence: 'hourly',
+      amount: BRANCH_COST_HOURLY,
+    });
+
+    const confirm_cost_id_result = await callTool({
+      name: 'confirm_cost',
+      arguments: cost,
+    });
+
+    const branchName = 'test-branch';
+    const branch = await callTool({
+      name: 'create_branch',
+      arguments: {
+        name: branchName,
+        confirm_cost_id: confirm_cost_id_result.confirmation_id,
+      },
+    });
+
+    expect(branch).toEqual(
+      expect.objectContaining({
+        name: branchName,
+        parent_project_ref: project.id,
+      })
+    );
+  });
+
+  test('branch workflow: create, list, and merge on a scoped connection', async () => {
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const { callTool } = await setup({
+      projectId: project.id,
+      features: ['branching', 'database'],
+    });
+
+    const confirm_cost_id_result = await callTool({
+      name: 'confirm_cost',
+      arguments: {
+        type: 'branch',
+        recurrence: 'hourly',
+        amount: BRANCH_COST_HOURLY,
+      },
+    });
+
+    const branch = await callTool({
+      name: 'create_branch',
+      arguments: {
+        name: 'feature-branch',
+        confirm_cost_id: confirm_cost_id_result.confirmation_id,
+      },
+    });
+
+    const listResult = await callTool({
+      name: 'list_branches',
+      arguments: {},
+    });
+
+    expect(listResult.branches).toContainEqual(
+      expect.objectContaining({ id: branch.id })
+    );
+
+    // Simulate a migration applied on the branch. In a real workflow this
+    // happens through a connection scoped to the branch's project_ref.
+    const branchProject = mockProjects.get(branch.project_ref);
+    if (!branchProject) {
+      throw new Error('branch project not found');
+    }
+    const migrationName = 'sample_migration';
+    const migrationVersion = '20240101000000';
+    branchProject.migrations.push({
+      version: migrationVersion,
+      name: migrationName,
+      query:
+        'create table sample (id integer generated always as identity primary key)',
+    });
+
+    await callTool({
+      name: 'merge_branch',
+      arguments: {
+        branch_id: branch.id,
+      },
+    });
+
+    // Check that the migration was applied to the scoped parent project
+    const migrationsResult = await callTool({
+      name: 'list_migrations',
+      arguments: {},
+    });
+
+    expect(migrationsResult.migrations).toContainEqual({
+      name: migrationName,
+      version: migrationVersion,
+    });
   });
 
   test('no tool should accept a project_id', async () => {

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -7,7 +7,7 @@ import {
 import packageJson from '../package.json' with { type: 'json' };
 import { createContentApiClient } from './content-api/index.js';
 import type { SupabasePlatform } from './platform/types.js';
-import { getAccountTools } from './tools/account-tools.js';
+import { getAccountTools, getCostTools } from './tools/account-tools.js';
 import { getBranchingTools } from './tools/branching-tools.js';
 import {
   type CostConfirmationState,
@@ -202,6 +202,16 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
                 : undefined,
           })
         );
+      } else if (
+        projectId &&
+        account &&
+        branching &&
+        enabledFeatures.has('branching')
+      ) {
+        // Without an elicitation-capable client, `create_branch` still requires
+        // a confirm_cost_id that only the cost tools produce, so keep them
+        // available in project-scoped mode even though account tools are not.
+        Object.assign(tools, getCostTools({ account }));
       }
 
       if (database && enabledFeatures.has('database')) {

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -32,6 +32,10 @@ type AccountToolsOptions = {
   };
 };
 
+type CostToolsOptions = {
+  account: AccountOperations;
+};
+
 const listOrganizationsInputSchema = z.object({});
 
 const listOrganizationsOutputSchema = z.object({
@@ -246,6 +250,38 @@ export const accountToolDefs = {
   },
 } as const satisfies ToolDefs;
 
+/**
+ * Cost confirmation tools (`get_cost` and `confirm_cost`).
+ *
+ * Part of the account tools, but also registered on their own in
+ * project-scoped mode (where account tools are unavailable) so that
+ * `create_branch` remains callable: without an elicitation-capable
+ * client it still requires a `confirm_cost_id` that only these produce.
+ */
+export function getCostTools({ account }: CostToolsOptions) {
+  return {
+    get_cost: tool({
+      ...accountToolDefs.get_cost,
+      execute: async ({ type, organization_id }) => {
+        switch (type) {
+          case 'project':
+            return await getNextProjectCost(account, organization_id);
+          case 'branch':
+            return getBranchCost();
+          default:
+            throw new Error(`Unknown cost type: ${type}`);
+        }
+      },
+    }),
+    confirm_cost: tool({
+      ...accountToolDefs.confirm_cost,
+      execute: async (cost) => {
+        return { confirmation_id: await hashObject(cost) };
+      },
+    }),
+  };
+}
+
 export function getAccountTools({
   account,
   readOnly,
@@ -276,25 +312,7 @@ export function getAccountTools({
         return await account.getProject(id);
       },
     }),
-    get_cost: tool({
-      ...accountToolDefs.get_cost,
-      execute: async ({ type, organization_id }) => {
-        switch (type) {
-          case 'project':
-            return await getNextProjectCost(account, organization_id);
-          case 'branch':
-            return getBranchCost();
-          default:
-            throw new Error(`Unknown cost type: ${type}`);
-        }
-      },
-    }),
-    confirm_cost: tool({
-      ...accountToolDefs.confirm_cost,
-      execute: async (cost) => {
-        return { confirmation_id: await hashObject(cost) };
-      },
-    }),
+    ...getCostTools({ account }),
     create_project: tool({
       ...accountToolDefs.create_project,
       parameters: costConfirmation

--- a/packages/mcp-server-supabase/src/tools/tool-schemas.test.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.test.ts
@@ -146,6 +146,49 @@ describe('createToolSchemas', () => {
       // delete_branch uses branch_id, not project_id - should use original schema
       expect(schemas.delete_branch).toBe(supabaseMcpToolSchemas.delete_branch);
     });
+
+    test('includes cost tools when branching is enabled', () => {
+      const schemas = createToolSchemas({ projectScoped: true });
+      const keys = Object.keys(schemas);
+
+      expect(keys).toContain('get_cost');
+      expect(keys).toContain('confirm_cost');
+
+      // Cost tools have no project_id - should use original schemas
+      expect(schemas.get_cost).toBe(supabaseMcpToolSchemas.get_cost);
+      expect(schemas.confirm_cost).toBe(supabaseMcpToolSchemas.confirm_cost);
+
+      expectTypeOf(schemas).toHaveProperty('get_cost');
+      expectTypeOf(schemas).toHaveProperty('confirm_cost');
+    });
+
+    test('excludes cost tools when branching is disabled', () => {
+      const schemas = createToolSchemas({
+        features: ['database', 'docs'],
+        projectScoped: true,
+      });
+      const keys = Object.keys(schemas);
+
+      expect(keys).not.toContain('get_cost');
+      expect(keys).not.toContain('confirm_cost');
+
+      expectTypeOf(schemas).not.toHaveProperty('get_cost');
+      expectTypeOf(schemas).not.toHaveProperty('confirm_cost');
+    });
+
+    test('excludes cost tools when only account is enabled', () => {
+      const schemas = createToolSchemas({
+        features: ['account'],
+        projectScoped: true,
+      });
+      const keys = Object.keys(schemas);
+
+      expect(keys).not.toContain('get_cost');
+      expect(keys).not.toContain('confirm_cost');
+
+      expectTypeOf(schemas).not.toHaveProperty('get_cost');
+      expectTypeOf(schemas).not.toHaveProperty('confirm_cost');
+    });
   });
 
   describe('readOnly', () => {

--- a/packages/mcp-server-supabase/src/tools/tool-schemas.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.ts
@@ -135,6 +135,16 @@ const PROJECT_SCOPED_OVERRIDES: Record<string, SchemaEntry> =
   );
 
 /**
+ * Cost tools that stay available in project-scoped mode when the
+ * branching feature is enabled, since `create_branch` requires a cost
+ * confirmation ID that can only be obtained from them.
+ * Matches server behavior in `server.ts`.
+ */
+const PROJECT_SCOPED_COST_TOOLS = ['get_cost', 'confirm_cost'] as const;
+
+type ProjectScopedCostToolName = (typeof PROJECT_SCOPED_COST_TOOLS)[number];
+
+/**
  * Tools excluded entirely in read-only mode.
  * Derived from tool defs: any tool with `readOnlyHint: false` and no
  * `readOnlyBehavior: 'adapt'` annotation.
@@ -188,18 +198,26 @@ type WriteToolName = {
  * Computes the set of tool names available for a given configuration.
  *
  * - Resolves feature groups to their tool names
- * - Excludes account tools when project-scoped
+ * - Excludes account tools when project-scoped, except the cost tools
+ *   which stay available when branching is enabled (so `create_branch`
+ *   remains callable)
  * - Excludes write-only tools when read-only
  */
 type AvailableToolNames<
   Feature extends FeatureGroup,
   ProjectScoped extends boolean,
   ReadOnly extends boolean,
-> = Exclude<
-  ToolNameForFeature<Feature>,
-  | (ProjectScoped extends true ? AccountToolName : never)
-  | (ReadOnly extends true ? WriteToolName : never)
->;
+> =
+  | Exclude<
+      ToolNameForFeature<Feature>,
+      | (ProjectScoped extends true ? AccountToolName : never)
+      | (ReadOnly extends true ? WriteToolName : never)
+    >
+  | (ProjectScoped extends true
+      ? 'branching' extends Feature
+        ? ProjectScopedCostToolName
+        : never
+      : never);
 
 /**
  * Computes the tool schemas for a given configuration.
@@ -226,7 +244,9 @@ type ToolSchemasFor<
  * Mirrors the server's dynamic tool behavior:
  * - `features` controls which tool groups are included
  * - `projectScoped` omits `project_id` from input schemas and excludes
- *   account tools (matching server behavior when `projectId` is set)
+ *   account tools, except `get_cost` and `confirm_cost` which stay
+ *   available when branching is enabled (matching server behavior when
+ *   `projectId` is set)
  * - `readOnly` excludes mutating tools
  *
  * @example
@@ -272,6 +292,12 @@ export function createToolSchemas<
       } else {
         result[toolName] = supabaseMcpToolSchemas[toolName];
       }
+    }
+  }
+
+  if (projectScoped && enabledFeatures.has('branching')) {
+    for (const toolName of PROJECT_SCOPED_COST_TOOLS) {
+      result[toolName] = supabaseMcpToolSchemas[toolName];
     }
   }
 


### PR DESCRIPTION
Fixes #285

In project-scoped mode the branching tools are registered, but `create_branch` requires a `confirm_cost_id` that can only be obtained from `confirm_cost`. The cost tools live in the account group, which is excluded when a project ref is pinned, so `create_branch` cannot be called at all in that mode.

This PR takes the first shape proposed in the issue: `get_cost` and `confirm_cost` are now also registered in project-scoped mode, gated on the branching feature being enabled and on the platform providing account and branching operations. That keeps the existing cost consent flow intact rather than dropping the `confirm_cost_id` requirement, and only adds tools to `tools/list`, which fits the expand and contract guidance in CONTRIBUTING.md. Tool names, schemas and descriptions are unchanged, so nothing shifts for unscoped or frozen clients. If you would prefer a different shape — making `confirm_cost_id` optional in scoped mode, or handling confirmation in the hosted layer — I am happy to rework this.

Two notes on scope. The `list_branches` half of the issue does not reproduce on current main, since the scoped project id is already injected there, so this PR only addresses the `create_branch` deadlock. The same deadlock also exists unscoped when branching is enabled without the account group, but an existing test pins that behavior as intended, so I left it alone and can follow up if you want it changed.

Test coverage added:

- `tools/list` in project scope includes `get_cost` and `confirm_cost` when branching is enabled, and still excludes them when it is not
- a scoped connection can run `get_cost`, `confirm_cost`, and `create_branch` end to end
- a scoped workflow regression: create a branch, list it, merge it, and verify the migration landed on the parent project, all over the same scoped connection
- `createToolSchemas` includes or excludes the cost tools to match the server, checked at runtime and at the type level

Verification steps (macOS, Node 24, pnpm 10):

- `pnpm typecheck`: clean
- `CI=true pnpm vitest run --project unit`: 217 passed (217)
- `CI=true pnpm vitest run --project integration` after `pnpm build`: 5 passed (5)
- `pnpm format:check`: clean, 82 files

The e2e specs were not run locally because they need an Anthropic API key; they run in CI. This change was made with AI assistance and I reviewed and verified the output; the test results above are from my machine.
