### PR TITLE
Fix release registry restoration and safe tag retries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       force_publish:
-        description: 'Skip release-please and publish current package.json versions'
+        description: 'Publish package versions from release_tag without creating a release'
         type: boolean
         default: false
+      release_tag:
+        description: 'Existing GitHub release tag to publish when force_publish is enabled'
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -41,19 +45,24 @@ jobs:
         if: ${{ inputs.force_publish == true }}
         env:
           GH_TOKEN: ${{ github.token }}
-          REF_TYPE: ${{ github.ref_type }}
-          REF_NAME: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          WORKFLOW_REF_TYPE: ${{ github.ref_type }}
+          WORKFLOW_REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [ "$REF_TYPE" != "tag" ]; then
-            echo "Select a release tag instead of a branch when running force_publish."
+          if [ "$WORKFLOW_REF_TYPE" != "branch" ] || [ "$WORKFLOW_REF_NAME" != "main" ]; then
+            echo "Select main when running force_publish."
             exit 1
           fi
-          if gh api --silent "repos/$GITHUB_REPOSITORY/releases/tags/$REF_NAME"; then
-            echo "Force publishing from release tag $REF_NAME."
+          if [ -z "$RELEASE_TAG" ]; then
+            echo "Enter an existing GitHub release tag when running force_publish."
+            exit 1
+          fi
+          if gh api --silent "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"; then
+            echo "Force publishing from release tag $RELEASE_TAG."
             exit 0
           fi
-          echo "Selected tag $REF_NAME is not associated with a GitHub Release."
+          echo "Selected tag $RELEASE_TAG is not associated with a GitHub Release."
           exit 1
 
       # Everything below runs when a release PR is merged, or when
@@ -69,6 +78,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: ${{ steps.release.outputs.releases_created || inputs.force_publish == true }}
+        with:
+          ref: ${{ inputs.force_publish == true && inputs.release_tag || github.sha }}
 
       - name: Setup tools
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
@@ -92,6 +103,10 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.release.outputs.releases_created || inputs.force_publish == true }}
         run: pnpm install --frozen-lockfile
+
+      - name: Restore npm registry
+        if: ${{ steps.release.outputs.releases_created || inputs.force_publish == true }}
+        run: npm config set registry https://registry.npmjs.org/
 
       - name: Build packages
         if: ${{ steps.release.outputs.releases_created || inputs.force_publish == true }}


### PR DESCRIPTION
## Summary

Fixes the [failed release](https://github.com/supabase/mcp/actions/runs/32367864313/job/96421339929) where `pnpm publish` inherited DepthFirst as npm's global registry and failed with E405.

The workflow now:

- restores `https://registry.npmjs.org/` immediately after dependency installation
- accepts a `release_tag` input for forced retries
- requires forced retries to run from `main`, validates the tag against an existing GitHub Release, then checks out that tag's package contents

This lets retries load the fixed workflow from `main` while publishing the exact tagged versions. Existing registry probes continue to skip versions already published.

## Verification

- actionlint v1.7.7 passed
- `mcp-utils-v0.7.0`, `mcp-server-supabase-v0.11.0`, and `mcp-server-postgrest-v0.2.0` resolve to `c2826ee85a66d4fd6d4ccfa5086ec823d4a9fc88`
- mcp-utils built
- npm publish dry-run targeted public npm