### PR TITLE
fix: name function_logs and event_message in the ClickHouse query_logs hint

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4056,6 +4056,11 @@ describe('feature groups', () => {
     // `function_logs`. See getClickHouseLogQuery in logs.ts.
     expect(sqlDescription).toContain("'function_edge_logs'");
     expect(sqlDescription).toContain("'function_logs'");
+    // The log line text lives in `event_message`; `log_attributes` carries only
+    // per-row metadata. Without naming the column the model reads
+    // `log_attributes`, finds no message key, and reports that the console
+    // output was never stored. See getClickHouseLogQuery in logs.ts.
+    expect(sqlDescription).toContain('event_message');
   });
 
   test('query_logs advertises the BigQuery dialect when the platform declares it', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4050,6 +4050,12 @@ describe('feature groups', () => {
 
     expect(queryLogs?.description).toContain('ClickHouse');
     expect(sqlDescription).toContain("log_attributes['<key>']");
+    // Edge Function logs are split across two ClickHouse sources. The hint must
+    // name both, or the model reaches for `function_edge_logs` (the request
+    // envelope) when the user asked for console output, which only lives in
+    // `function_logs`. See getClickHouseLogQuery in logs.ts.
+    expect(sqlDescription).toContain("'function_edge_logs'");
+    expect(sqlDescription).toContain("'function_logs'");
   });
 
   test('query_logs advertises the BigQuery dialect when the platform declares it', async () => {

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -97,7 +97,7 @@ const queryLogsByDialect = {
     name: 'ClickHouse',
     logsNoun: 'unified logs stream',
     schemaHint:
-      "Logs are exposed through a `logs` table; filter by `source` (common values include 'edge_logs', 'postgres_logs', 'function_edge_logs' for Edge Function invocation/request logs, and 'function_logs' for console output from inside an Edge Function, but this list is not exhaustive — run `select distinct source from logs` to discover the sources available for this project) and read nested fields via `log_attributes['<key>']`.",
+            "Logs are exposed through a `logs` table; filter by `source` (common values include 'edge_logs', 'postgres_logs', 'function_edge_logs' for Edge Function invocation/request logs, and 'function_logs' for console output from inside an Edge Function, but this list is not exhaustive — run `select distinct source from logs` to discover the sources available for this project) and read the log line text from `event_message` (the console output or message body); `log_attributes['<key>']` holds only per-row metadata such as level, execution_id and status code.",
   }),
   bigquery: buildQueryLogsCopy({
     name: 'BigQuery',

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -97,7 +97,7 @@ const queryLogsByDialect = {
     name: 'ClickHouse',
     logsNoun: 'unified logs stream',
     schemaHint:
-            "Logs are exposed through a `logs` table; filter by `source` (common values include 'edge_logs', 'postgres_logs', 'function_edge_logs' for Edge Function invocation/request logs, and 'function_logs' for console output from inside an Edge Function, but this list is not exhaustive — run `select distinct source from logs` to discover the sources available for this project) and read the log line text from `event_message` (the console output or message body); `log_attributes['<key>']` holds only per-row metadata such as level, execution_id and status code.",
+      "Logs are exposed through a `logs` table; filter by `source` (common values include 'edge_logs', 'postgres_logs', 'function_edge_logs' for Edge Function invocation/request logs, and 'function_logs' for console output from inside an Edge Function, but this list is not exhaustive — run `select distinct source from logs` to discover the sources available for this project) and read the log line text from `event_message` (the console output or message body); `log_attributes['<key>']` holds only per-row metadata such as level, execution_id and status code.",
   }),
   bigquery: buildQueryLogsCopy({
     name: 'BigQuery',

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -97,7 +97,7 @@ const queryLogsByDialect = {
     name: 'ClickHouse',
     logsNoun: 'unified logs stream',
     schemaHint:
-      "Logs are exposed through a `logs` table; filter by `source` (common values include 'edge_logs', 'postgres_logs', and 'function_edge_logs', but this list is not exhaustive — run `select distinct source from logs` to discover the sources available for this project) and read nested fields via `log_attributes['<key>']`.",
+      "Logs are exposed through a `logs` table; filter by `source` (common values include 'edge_logs', 'postgres_logs', 'function_edge_logs' for Edge Function invocation/request logs, and 'function_logs' for console output from inside an Edge Function, but this list is not exhaustive — run `select distinct source from logs` to discover the sources available for this project) and read nested fields via `log_attributes['<key>']`.",
   }),
   bigquery: buildQueryLogsCopy({
     name: 'BigQuery',


### PR DESCRIPTION
Closes #375

## Problem

On hosted projects `get_logs` is hidden, so `query_logs` is the only logs tool. Its ClickHouse
hint names `function_edge_logs` but not `function_logs`, and tells the model to read
`log_attributes['<key>']` without mentioning `event_message`. `log_attributes` holds only
metadata (level, execution_id, request_id); the log line text lives solely in `event_message`.

The result is a model that reaches the right table, reads the wrong column, and tells the user
their output was never stored:

> "The console.log output from your order-sync edge function is not being stored in the
> queryable project logs."

## Change

Names both Edge Function sources, and states that `event_message` carries the log line while
`log_attributes` carries metadata. Additive prose only; the `select distinct source from logs`
escape hatch is unchanged, and the BigQuery hint is untouched (self-hosted Logflare does not
serve `function_logs`, and its `not.toContain` assertion still passes).

## Evidence

32-run matrix against a live project (4 models × 2 prompts × 2 reasoning levels × 2 builds),
test function returning HTTP 200 on every call while logging an `error` line, graded on whether
the answer contains the actual error text.

- Naming the source alone: 14 comparable cells, **zero changed**. Models already reach
  `function_logs` unaided (Haiku did so in 7/7 runs on both builds).
- Adding `event_message`: the 5 previously-failing cells, 2 replicates each, **10/10 pass**,
  median 1.5 queries versus a median of 4 while failing.

Local: `pnpm run build`, 215/215 unit tests, `pnpm typecheck` clean,
`npx @biomejs/biome@1.9.4 ci .` clean (89 files).

Two caveats: an earlier version of this description presented a scripted client with hardcoded
SQL as though an agent had chosen the query, which overstated it. And I retested only
previously-failing cells, so I have not shown the new wording leaves passing cells alone.

## Published metadata

This edits a `.describe()` string, in the frozen-fields list. Purely additive, no schema shape
or optionality change, so it should fit the expand step, but flagging in case it should be
folded into the next plugin submission.