### PR TITLE
fix(pg-meta): order primary key columns by key position and exclude INCLUDE columns

### DIFF
--- a/packages/mcp-server-supabase/src/pg-meta/tables.sql
+++ b/packages/mcp-server-supabase/src/pg-meta/tables.sql
@@ -26,26 +26,30 @@ FROM
   pg_namespace nc
   JOIN pg_class c ON nc.oid = c.relnamespace
   left join (
+    -- Walk indkey positionally: `= any (indkey)` discards the position of each
+    -- column within the key, so rows come back in attnum order rather than
+    -- constraint-definition order. indkey also holds the index's INCLUDE payload
+    -- columns, which are not part of the key -- indnkeyatts bounds it to the real
+    -- key columns. Same ordering guarantee the foreign key subquery below relies on.
     select
       table_id,
-      jsonb_agg(_pk.*) as primary_keys
+      jsonb_agg(to_jsonb(_pk) - 'ord' order by _pk.ord) as primary_keys
     from (
       select
         n.nspname as schema,
         c.relname as table_name,
         a.attname as name,
-        c.oid :: int8 as table_id
+        c.oid :: int8 as table_id,
+        k.ord
       from
-        pg_index i,
-        pg_class c,
-        pg_attribute a,
-        pg_namespace n
+        pg_index i
+        join pg_class c on i.indrelid = c.oid
+        join pg_namespace n on c.relnamespace = n.oid
+        cross join lateral unnest(i.indkey :: int2[]) with ordinality as k(attnum, ord)
+        join pg_attribute a on a.attrelid = c.oid and a.attnum = k.attnum
       where
-        i.indrelid = c.oid
-        and c.relnamespace = n.oid
-        and a.attrelid = c.oid
-        and a.attnum = any (i.indkey)
-        and i.indisprimary
+        i.indisprimary
+        and k.ord <= i.indnkeyatts
     ) as _pk
     group by table_id
   ) as pk

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -1559,6 +1559,91 @@ describe('tools', () => {
     ).toHaveLength(1);
   });
 
+  test('composite primary key preserves constraint-definition column order', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    // Key order is deliberately the reverse of the physical column order, so a
+    // regression to attnum ordering fails immediately. This mirrors the ordering
+    // guarantee the foreign key tests above already assert.
+    await project.db.exec(`
+      create table membership (
+        org_id int not null,
+        user_id int not null,
+        role text,
+        primary key (user_id, org_id)
+      );
+    `);
+
+    const result = await callTool({
+      name: 'list_tables',
+      arguments: {
+        project_id: project.id,
+        schemas: ['public'],
+        verbose: true,
+      },
+    });
+
+    const membership = result.tables.find(
+      (t: { name: string }) => t.name === 'public.membership'
+    );
+
+    expect(membership.primary_keys).toEqual(['user_id', 'org_id']);
+  });
+
+  test('primary key excludes non-key INCLUDE columns', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    // `b` is an INCLUDE payload column: carried in the index for index-only scans,
+    // but not part of the key and not covered by the uniqueness guarantee. Reporting
+    // it as a primary key column overstates what the database enforces.
+    await project.db.exec(`
+      create table inc (a int not null, b int not null, c int not null);
+      create unique index inc_pk_idx on inc (a) include (b);
+      alter table inc add constraint inc_pk primary key using index inc_pk_idx;
+    `);
+
+    const result = await callTool({
+      name: 'list_tables',
+      arguments: {
+        project_id: project.id,
+        schemas: ['public'],
+        verbose: true,
+      },
+    });
+
+    const inc = result.tables.find(
+      (t: { name: string }) => t.name === 'public.inc'
+    );
+
+    expect(inc.primary_keys).toEqual(['a']);
+  });
+
   test('list_tables omits advisory when all tables have RLS enabled', async () => {
     const { callTool } = await setup();
 


### PR DESCRIPTION
Closes #381

### What kind of change does this PR introduce?

Bug fix: data-integrity issue in `list_tables` (verbose) primary key output.

### What is the current behavior?

`primary_keys` is sorted by each column's physical position in the table rather than its position in the key, and it includes the non-key `INCLUDE` payload columns of the backing index.

```sql
create table membership (
  org_id  int not null,          -- physically column 1
  user_id int not null,          -- physically column 2
  role    text,
  primary key (user_id, org_id)
);

create table inc (a int not null, b int not null, c int not null);
create unique index inc_pk_idx on inc (a) include (b);
alter table inc add constraint inc_pk primary key using index inc_pk_idx;
```

| table | declared | reported |
|---|---|---|
| `membership` | `(user_id, org_id)` | `["org_id","user_id"]` |
| `inc` | `(a) INCLUDE (b)` | `["a","b"]` |

Root cause in `pg-meta/tables.sql`: `a.attnum = any (i.indkey)` is a set-membership test, so each column's position within the key is discarded and the enclosing `jsonb_agg` has no `order by`. `indkey` also spans `indnatts`, which includes the `INCLUDE` payload, rather than `indnkeyatts`.

This is the same defect #317 fixed in the foreign key subquery immediately below, which walks columns with `unnest(...) with ordinality` and aggregates `order by cols.ord`. The primary key subquery was not updated at the time.

### What is the new behavior?

- `indkey` is unnested `with ordinality` and the aggregate is ordered by that ordinal, so columns come back in constraint-definition order - not attnum, not alphabetical.
- The unnest is bounded by `indnkeyatts`, so `INCLUDE` payload columns are excluded.
- The implicit comma joins become explicit joins, which is what makes the lateral unnest readable. Output shape is unchanged: `to_jsonb(_pk) - 'ord'` emits exactly the same keys as before.
- A comment records why `= any (indkey)` is wrong, so it doesn't get "simplified" back.

Two regression tests, both using a key order that is deliberately the reverse of the physical column order so any regression to attnum ordering fails immediately - the same shape as the FK ordering test added in #317.

### Verification

Windows 11, Node 22 LTS, pnpm 10:

```
pnpm run build                            -> success
CI=true pnpm vitest run --project unit    -> 212 passed | 5 failed (217)
pnpm typecheck                            -> clean
npx @biomejs/biome@1.9.4 ci .             -> Checked 89 files. No fixes applied.
```

Both new tests pass:

```
✓ tools > composite primary key preserves constraint-definition column order
✓ tools > primary key excludes non-key INCLUDE columns
```

**The 5 failures are pre-existing and unrelated to this change.** They are all `normalizeFilename`: `edge-function.ts` imports `resolve` from `node:path`, which is platform-dispatched, but strips a hardcoded POSIX prefix (`/tmp/user_fn_.../`), so on Windows the strip never matches and the full `C:\tmp\...` path is returned. 3 direct failures in `edge-function.test.ts` plus 2 downstream in `server.test.ts` (`list edge functions`, `get edge function`). I confirmed the identical 5 failures on clean `upstream/main` with nothing applied, so they are the baseline, not a regression. Happy to file that separately - `node:path/posix` looks like the one-line fix, and every caller already forces POSIX semantics with `fileURLToPath(..., { windows: false })`.

End to end against a real MCP client and server (`createSupabaseMcpServer` over `StreamTransport`, PostgreSQL 16.4 via PGlite), calling `list_tables` with `verbose: true`:

```
before   membership  declared (user_id, org_id)   ->  ["org_id","user_id"]
         triple      declared (r, q, p)           ->  ["p","q","r"]
         inc         declared (a) INCLUDE (b)     ->  ["a","b"]

after    membership                               ->  ["user_id","org_id"]
         triple                                   ->  ["r","q","p"]
         inc                                      ->  ["a"]
```

Single-column primary keys and the composite foreign key output from #317 are unchanged on both builds.

### On whether this actually misleads a model

I tested it rather than asserting it, and the result is mostly negative, so it's worth stating plainly: across 18 runs (3 models × 3 questions × before/after, one replicate per cell) **17 answered correctly on both builds**. Models generally did not trust `primary_keys` - 17 of 18 runs called `execute_sql` and read `pg_index`/`pg_constraint` directly. Two runs spontaneously flagged the output as wrong, e.g. *"list_tables reports the primary key as ["a","b"], which is misleading: it lumps the INCLUDE column in with the real key column."*

The one failure was a weaker model on "what's the primary key on membership?" against the unfixed build, which answered `org_id, user_id`. Notably its own verification query used `information_schema.key_column_usage` without `order by ordinal_position`, so it confirmed the wrong answer.

So the case for this fix is not "agents give wrong answers". It's that `primary_keys` contradicts the database, that models are paying for a catalog round-trip `list_tables` exists to save, and that a non-agent consumer of the published package has no fallback at all.

### What I did not test

- Only against PGlite (PostgreSQL 16.4) and the repo's test harness, not a live Supabase project. `indnkeyatts` requires PG 11+.
- One replicate per cell in the model matrix, and those runners were agents with shell access, which lean toward verifying - a plain chat client may lean on `list_tables` more than these did.