### PR TITLE
docs: add How to Review guidance via PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,11 +45,10 @@ Non-trivial or multi-file PRs must fill in the reading path below. Trivial singl
 - [ ] Do failures stop safely?
 - [ ] Do tests protect observable behavior rather than implementation details?
 
+## Verification
+
+How you verified the change. Include the steps and evidence (commands, test output, screenshots). AI-assisted contributions are welcome, but a human must review and verify the output.
+
 ## Additional context
 
 Add any other context or screenshots.
-
-<!--
-AI-assisted contributions are welcome, but a human must review and verify the output.
-Include the verification steps and evidence (screenshots, test output, etc.).
--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,14 @@
-## What
+## What kind of change does this PR introduce?
 
-<!-- What does this PR change? One or two sentences. -->
+Bug fix, feature, docs update, ...
 
-## Why
+## What is the current behavior?
 
-<!-- Why is this change needed? Link the accepted issue. -->
+Please link any relevant issues here.
+
+## What is the new behavior?
+
+Feel free to include screenshots if it includes visual changes.
 
 ## How to Review
 
@@ -41,7 +45,9 @@ Non-trivial or multi-file PRs must fill in the reading path below. Trivial singl
 - [ ] Do failures stop safely?
 - [ ] Do tests protect observable behavior rather than implementation details?
 
-## Verification
+## Additional context
+
+Add any other context or screenshots.
 
 <!--
 AI-assisted contributions are welcome, but a human must review and verify the output.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+## What
+
+<!-- What does this PR change? One or two sentences. -->
+
+## Why
+
+<!-- Why is this change needed? Link the accepted issue. -->
+
+## How to Review
+
+<!--
+A reviewer should understand what this PR does within 15-30 seconds, then know where to start reading.
+
+Non-trivial or multi-file PRs must fill in the reading path below. Trivial single-file changes may delete this section when the review path is obvious.
+
+- Start from the main public entrypoint or request handler, and follow the actual execution path before reading tests.
+- Use bold numbered areas, each with one or two indented bullets: the exact files, then what to inspect.
+- Use exact repository-relative paths, and avoid line numbers while the branch is still changing.
+- Prefer project-facing language such as `interface`, `extension point`, or `contract` over internal design jargon.
+- Don't repeat the PR purpose or the verification commands here. Keep the section scannable.
+-->
+
+1. **Review area**
+   - `path/to/main-entrypoint.ts`
+   - What to follow or verify.
+
+2. **Next review area**
+   - `path/to/next-file.ts`
+   - What to follow or verify.
+
+3. **Tests**
+   - Exact test files
+   - Which observable contracts they protect.
+
+**Review questions**
+
+<!-- Four to six short questions covering the reviewer's judgment calls. -->
+
+- [ ] Is the public contract minimal and intentional?
+- [ ] Do the main execution paths preserve existing behavior?
+- [ ] Do failures stop safely?
+- [ ] Do tests protect observable behavior rather than implementation details?
+
+## Verification
+
+<!--
+AI-assisted contributions are welcome, but a human must review and verify the output.
+Include the verification steps and evidence (screenshots, test output, etc.).
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,46 @@ Before opening an issue or PR, please read this guide.
 - **PRs** should address an accepted issue. Open an issue first for new features or behavior changes so we can agree on the approach before you invest time coding. PRs that promote unaffiliated products or services will be closed.
 - AI-assisted contributions are welcome, but a human must review and verify the output. Include verification steps and evidence (screenshots, test output, etc.) in the PR description.
 
+## PR descriptions
+
+A reviewer should understand what a PR does within 15-30 seconds, then know where to start reading.
+
+Non-trivial or multi-file PRs must include a `## How to Review` section that lays out the reading path. Trivial single-file changes may leave it out when the review path is obvious.
+
+- Start from the main public entrypoint or request handler, and follow the actual execution path before reading tests.
+- Use bold numbered areas, each with one or two indented bullets: the exact files, then what to inspect.
+- Use exact repository-relative paths, and avoid line numbers while the branch is still changing.
+- Close with four to six short checkbox questions covering the reviewer's judgment calls.
+- Prefer project-facing language such as `interface`, `extension point`, or `contract` over internal design jargon.
+- Don't repeat the PR purpose or the verification commands here. Keep the section scannable.
+
+```markdown
+## How to Review
+
+1. **Review area**
+   - `path/to/main-entrypoint.ts`
+   - What to follow or verify.
+
+2. **Next review area**
+   - `path/to/next-file.ts`
+   - What to follow or verify.
+
+3. **Integration or behavior**
+   - Exact relevant files
+   - What contract or behavior to inspect.
+
+4. **Tests**
+   - Exact test files
+   - Which observable contracts they protect.
+
+**Review questions**
+
+- [ ] Is the public contract minimal and intentional?
+- [ ] Do the main execution paths preserve existing behavior?
+- [ ] Do failures stop safely?
+- [ ] Do tests protect observable behavior rather than implementation details?
+```
+
 ## Development setup
 
 This repo uses pnpm for package management and the active LTS version of Node.js. Node.js and pnpm versions are managed via [mise](https://mise.jdx.dev/) (see `mise.toml`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,46 +6,6 @@ Before opening an issue or PR, please read this guide.
 - **PRs** should address an accepted issue. Open an issue first for new features or behavior changes so we can agree on the approach before you invest time coding. PRs that promote unaffiliated products or services will be closed.
 - AI-assisted contributions are welcome, but a human must review and verify the output. Include verification steps and evidence (screenshots, test output, etc.) in the PR description.
 
-## PR descriptions
-
-A reviewer should understand what a PR does within 15-30 seconds, then know where to start reading.
-
-Non-trivial or multi-file PRs must include a `## How to Review` section that lays out the reading path. Trivial single-file changes may leave it out when the review path is obvious.
-
-- Start from the main public entrypoint or request handler, and follow the actual execution path before reading tests.
-- Use bold numbered areas, each with one or two indented bullets: the exact files, then what to inspect.
-- Use exact repository-relative paths, and avoid line numbers while the branch is still changing.
-- Close with four to six short checkbox questions covering the reviewer's judgment calls.
-- Prefer project-facing language such as `interface`, `extension point`, or `contract` over internal design jargon.
-- Don't repeat the PR purpose or the verification commands here. Keep the section scannable.
-
-```markdown
-## How to Review
-
-1. **Review area**
-   - `path/to/main-entrypoint.ts`
-   - What to follow or verify.
-
-2. **Next review area**
-   - `path/to/next-file.ts`
-   - What to follow or verify.
-
-3. **Integration or behavior**
-   - Exact relevant files
-   - What contract or behavior to inspect.
-
-4. **Tests**
-   - Exact test files
-   - Which observable contracts they protect.
-
-**Review questions**
-
-- [ ] Is the public contract minimal and intentional?
-- [ ] Do the main execution paths preserve existing behavior?
-- [ ] Do failures stop safely?
-- [ ] Do tests protect observable behavior rather than implementation details?
-```
-
 ## Development setup
 
 This repo uses pnpm for package management and the active LTS version of Node.js. Node.js and pnpm versions are managed via [mise](https://mise.jdx.dev/) (see `mise.toml`).


### PR DESCRIPTION
## What

This moves the PR review guidance into a local pull request template, following @raulb's review suggestion.

The template keeps the four prompts from the inherited `supabase/.github` template and adds two sections:

- `## How to Review`: numbered review areas linked to repo-relative file paths, plus a short checklist of review questions
- `## Verification`: a visible place for the steps and evidence that `CONTRIBUTING.md` requires

Author guidance lives in HTML comments, so it stays hidden in posted PRs.

## Why

Authors now see the review guidance inline when opening a new PR in `supabase/mcp`. Existing PR bodies stay unchanged.

## How to Review

1. Open [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
2. Confirm it builds on the inherited org template and preserves all four prompts: change type, current behavior, new behavior, and additional context.
3. Confirm `## How to Review` asks for a numbered reading path with repo-relative file paths and a short review-questions checklist.
4. Confirm `## Verification` is a visible section (not a hidden comment) so authors have a clear place for steps and evidence.
5. Confirm the remaining author guidance is inside HTML comments and will not render in the posted PR body.

## Verification

The net diff against `origin/main` is one new file: `.github/PULL_REQUEST_TEMPLATE.md` (+54 lines). The earlier `CONTRIBUTING.md` changes are fully reverted.
