### PR TITLE
Simplify hosted cost confirmation with SDK elicitation

### DIFF
--- a/packages/mcp-server-supabase/src/cost-confirmation.test.ts
+++ b/packages/mcp-server-supabase/src/cost-confirmation.test.ts
@@ -1,0 +1,858 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import {
+  createMcpHandler,
+  createRequestStateCodec,
+  type ClientCapabilities,
+  type ElicitResult,
+  type Server,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
+import { StreamTransport } from '@supabase/mcp-utils';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  BRANCH_RATE,
+  createCostPlatform,
+  FIXED_PROJECT,
+  PROJECT_RATE,
+} from '../test/cost-platform.js';
+import {
+  type CostConfirmationResolution,
+  createCreationOutcomeText,
+  type CreationRate,
+} from './cost-confirmation.js';
+import {
+  createSupabaseMcpServer,
+  type SupabaseMcpServerOptions,
+} from './server.js';
+
+const MODERN_PROTOCOL_VERSION = '2026-07-28';
+const MCP_ENDPOINT = new URL('https://mcp.test');
+const STATE_KEY = 'sdk-cost-confirmation-key-long-enough';
+const PROJECT_ARGS = {
+  name: 'Fixture Project',
+  region: 'us-east-1',
+  organization_id: 'fixed-org',
+};
+const BRANCH_ARGS = { project_id: 'fixed-project-ref', name: 'develop' };
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup();
+  }
+});
+
+type RequestBody = {
+  method?: string;
+  params?: {
+    arguments?: Record<string, unknown>;
+    inputResponses?: Record<string, unknown>;
+    requestState?: string;
+  };
+};
+
+type SetupOptions = {
+  answers?: ElicitResult[];
+  capabilities?: ClientCapabilities;
+  optOut?: boolean;
+  formDeliveryAvailable?: boolean;
+  actor?: { value: string };
+  methodBinding?: { value?: string };
+  projectId?: string;
+  readOnly?: boolean;
+  enabled?: () => boolean;
+  onContinuation?: (body: RequestBody) => void;
+};
+
+async function setupModern(options: SetupOptions = {}) {
+  const cost = createCostPlatform();
+  const actor = options.actor ?? { value: 'actor-1' };
+  const bindMethods: string[] = [];
+  const policyCalls: Array<{
+    decision: string;
+    telemetry: {
+      interactionId?: string;
+      outcome?: string;
+      reason?: string;
+    };
+  }> = [];
+  const serverOptions: SupabaseMcpServerOptions = {
+    platform: cost.platform,
+    features: ['account', 'branching'],
+    projectId: options.projectId,
+    readOnly: options.readOnly,
+  };
+  const handler = createMcpHandler(
+    () =>
+      createSupabaseMcpServer({
+        ...serverOptions,
+        elicitation: {
+          key: STATE_KEY,
+          bind(ctx) {
+            bindMethods.push(ctx.mcpReq.method);
+            return `${actor.value}\0${
+              options.methodBinding?.value ?? ctx.mcpReq.method
+            }`;
+          },
+          readProjectCreationRate: cost.readProjectCreationRate,
+          readBranchCreationRate: cost.readBranchCreationRate,
+          formDeliveryAvailable: options.formDeliveryAvailable ?? true,
+          optOut: options.optOut,
+          enabled: options.enabled ?? (() => true),
+          onToolPolicyCall: (details) => {
+            policyCalls.push(details);
+          },
+        },
+      }),
+    { legacy: 'reject' }
+  );
+  const requestStates: string[] = [];
+  const forcedRequestState: { value?: string } = {};
+  const transport = new StreamableHTTPClientTransport(MCP_ENDPOINT, {
+    fetch: async (url, init) => {
+      const body = (await new Request(url, init).json()) as RequestBody;
+      if (
+        body.method === 'tools/call' &&
+        body.params !== undefined &&
+        body.params.requestState === undefined &&
+        forcedRequestState.value !== undefined
+      ) {
+        body.params.requestState = forcedRequestState.value;
+      }
+      if (typeof body.params?.requestState === 'string') {
+        requestStates.push(body.params.requestState);
+        options.onContinuation?.(body);
+      }
+      return handler.fetch(
+        new Request(url, { ...init, body: JSON.stringify(body) })
+      );
+    },
+  });
+  const client = new Client(
+    { name: 'cost-policy-client', version: '1.0.0' },
+    {
+      capabilities: options.capabilities ?? { elicitation: { form: {} } },
+      versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } },
+    }
+  );
+  const elicitationRequests: unknown[] = [];
+  const answers = options.answers ?? [{ action: 'accept' }];
+  if ((options.capabilities ?? { elicitation: {} }).elicitation !== undefined) {
+    client.setRequestHandler('elicitation/create', async (request) => {
+      elicitationRequests.push(request.params);
+      const answer = answers.shift();
+      if (answer === undefined) {
+        throw new Error('no elicitation answer left');
+      }
+      return answer;
+    });
+  }
+
+  await client.connect(transport);
+  cleanups.push(
+    () => client.close(),
+    () => handler.close()
+  );
+  return {
+    client,
+    elicitationRequests,
+    requestStates,
+    policyCalls,
+    bindMethods,
+    forcedRequestState,
+    ...cost,
+  };
+}
+
+function textOf(result: { content?: unknown }): string {
+  if (!Array.isArray(result.content)) {
+    return '';
+  }
+  return result.content
+    .map((entry) =>
+      entry !== null &&
+      typeof entry === 'object' &&
+      'text' in entry &&
+      typeof entry.text === 'string'
+        ? entry.text
+        : ''
+    )
+    .join('');
+}
+
+function decodeState(state: string): Record<string, unknown> {
+  const body = state.split('.')[1];
+  if (body === undefined) {
+    throw new Error('request state has no body');
+  }
+  const decoded = JSON.parse(
+    Buffer.from(body, 'base64url').toString('utf8')
+  ) as { p?: Record<string, unknown> };
+  if (decoded.p === undefined) {
+    throw new Error('request state has no payload');
+  }
+  return decoded.p;
+}
+async function sealState(payload: Record<string, unknown>) {
+  const codec = createRequestStateCodec<unknown>({
+    key: STATE_KEY,
+    ttlSeconds: 120,
+    bind: (ctx) => `actor-1\0${ctx.mcpReq.method}`,
+  });
+  return codec.mint(payload, {
+    mcpReq: { method: 'tools/call' },
+  } as unknown as ServerContext);
+}
+
+describe('direct SDK cost confirmation', () => {
+  test('accepts an action-only project confirmation with sealed policy state', async () => {
+    const setup = await setupModern();
+
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+
+    expect(setup.elicitationRequests).toStrictEqual([
+      expect.objectContaining({
+        mode: 'form',
+        requestedSchema: { type: 'object', properties: {} },
+      }),
+    ]);
+    expect(JSON.stringify(setup.elicitationRequests[0])).toContain(
+      '10 USD per month'
+    );
+    expect(result.structuredContent).toStrictEqual(FIXED_PROJECT);
+    expect(textOf(result)).toContain('The client reported');
+    expect(setup.calls).toStrictEqual([
+      'read_project_rate',
+      'read_project_rate',
+      'create_project',
+    ]);
+
+    const state = decodeState(setup.requestStates[0]!);
+    expect(state).toMatchObject({
+      policy: 'supabase.cost_confirmation',
+      tool: 'create_project',
+      approvedRate: PROJECT_RATE,
+      policyVersion: 2,
+    });
+    expect(state.argsDigest).toEqual(expect.any(String));
+    expect(state.interactionId).toEqual(expect.any(String));
+  });
+  test('accept action ignores irrelevant response content', async () => {
+    const setup = await setupModern({
+      answers: [
+        {
+          action: 'accept',
+          content: { confirm: false, approved: 'no' },
+        },
+      ],
+    });
+
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+
+    expect(result.structuredContent).toStrictEqual(FIXED_PROJECT);
+    expect(setup.calls).toContain('create_project');
+  });
+
+  test('accepts a branch at the authoritative hourly rate', async () => {
+    const setup = await setupModern();
+
+    const result = await setup.client.callTool({
+      name: 'create_branch',
+      arguments: BRANCH_ARGS,
+    });
+
+    expect(textOf(result)).toContain('0.01344 USD per hour');
+    expect(setup.calls).toStrictEqual([
+      'read_branch_rate',
+      'read_branch_rate',
+      'create_branch',
+    ]);
+  });
+  test('accepts a projectId-injected branch and binds the injected project', async () => {
+    const setup = await setupModern({ projectId: 'fixed-project-ref' });
+    const { tools } = await setup.client.listTools();
+    const createBranch = tools.find((tool) => tool.name === 'create_branch');
+
+    const result = await setup.client.callTool({
+      name: 'create_branch',
+      arguments: { name: 'develop' },
+    });
+
+    expect(createBranch?.inputSchema.properties).not.toHaveProperty(
+      'project_id'
+    );
+    expect(result.isError).not.toBe(true);
+    expect(setup.calls).toStrictEqual([
+      'read_branch_rate',
+      'read_branch_rate',
+      'create_branch',
+    ]);
+  });
+
+  test('rejects injected branch argument drift', async () => {
+    const setup = await setupModern({
+      projectId: 'fixed-project-ref',
+      onContinuation(body) {
+        if (body.params?.arguments !== undefined) {
+          body.params.arguments.name = 'changed-after-prompt';
+        }
+      },
+    });
+
+    const result = await setup.client.callTool({
+      name: 'create_branch',
+      arguments: { name: 'develop' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('arguments changed');
+    expect(setup.calls).not.toContain('create_branch');
+  });
+
+  test('keeps decline and cancel distinct and creates nothing', async () => {
+    for (const action of ['decline', 'cancel'] as const) {
+      const setup = await setupModern({ answers: [{ action }] });
+      const result = await setup.client.callTool({
+        name: 'create_project',
+        arguments: PROJECT_ARGS,
+      });
+
+      expect(result.structuredContent).toStrictEqual({
+        status: action === 'decline' ? 'declined' : 'cancelled',
+      });
+      expect(textOf(result)).toContain(
+        action === 'decline' ? 'declined' : 'dismissed'
+      );
+      expect(setup.calls).not.toContain('create_project');
+    }
+  });
+  test.each([
+    [
+      'missing',
+      (body: RequestBody) => {
+        if (body.params !== undefined) {
+          delete body.params.inputResponses;
+        }
+      },
+    ],
+    [
+      'malformed',
+      (body: RequestBody) => {
+        if (body.params !== undefined) {
+          body.params.inputResponses = {
+            cost_confirmation: { malformed: true },
+          };
+        }
+      },
+    ],
+    [
+      'raw boolean',
+      (body: RequestBody) => {
+        if (body.params !== undefined) {
+          body.params.inputResponses = { cost_confirmation: true };
+        }
+      },
+    ],
+  ])(
+    'fails closed with rerun guidance for a %s response',
+    async (_case, mutate) => {
+      const setup = await setupModern({ onContinuation: mutate });
+
+      const result = await setup.client.callTool({
+        name: 'create_project',
+        arguments: PROJECT_ARGS,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain('no answer');
+      expect(textOf(result)).toContain('Run the tool again');
+      expect(setup.calls).not.toContain('create_project');
+    }
+  );
+
+  test('executes a zero authoritative rate without asking and still rechecks', async () => {
+    const setup = await setupModern();
+    const free: CreationRate = { ...PROJECT_RATE, amount: 0 };
+    setup.projectRates.push(free, free);
+
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+
+    expect(setup.elicitationRequests).toHaveLength(0);
+    expect(textOf(result)).toContain('no confirmation was requested');
+    expect(setup.calls).toStrictEqual([
+      'read_project_rate',
+      'read_project_rate',
+      'create_project',
+    ]);
+  });
+
+  test('rejects a stale final authoritative rate before creation', async () => {
+    const setup = await setupModern();
+    setup.projectRates.push(PROJECT_RATE, { ...PROJECT_RATE, amount: 11 });
+
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('approved_rate_stale');
+    expect(setup.calls).not.toContain('create_project');
+  });
+
+  test('rejects request-state tampering before policy re-entry', async () => {
+    const setup = await setupModern({
+      onContinuation(body) {
+        const state = body.params?.requestState;
+        if (state !== undefined) {
+          const replacement = state.endsWith('x') ? 'y' : 'x';
+          body.params!.requestState = `${state.slice(0, -1)}${replacement}`;
+        }
+      },
+    });
+
+    await expect(
+      setup.client.callTool({ name: 'create_project', arguments: PROJECT_ARGS })
+    ).rejects.toMatchObject({
+      code: -32602,
+      message: 'Invalid or expired requestState',
+    });
+    expect(setup.calls).not.toContain('create_project');
+  });
+  test('rejects valid state when redeemed by another tool', async () => {
+    const setup = await setupModern();
+    await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+    setup.forcedRequestState.value = setup.requestStates[0];
+
+    const result = await setup.client.callTool({
+      name: 'create_branch',
+      arguments: BRANCH_ARGS,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('incompatible policy version');
+    expect(setup.calls).not.toContain('create_branch');
+    expect(setup.calls).not.toContain('read_branch_rate');
+  });
+
+  test.each([
+    [
+      'wrong policy identity',
+      (payload: Record<string, unknown>) => {
+        payload.policy = 'another.policy';
+      },
+    ],
+    [
+      'malformed approved rate',
+      (payload: Record<string, unknown>) => {
+        payload.approvedRate = {
+          amount: '10',
+          currency: 'USD',
+          recurrence: 'monthly',
+        };
+      },
+    ],
+    [
+      'missing current field',
+      (payload: Record<string, unknown>) => {
+        delete payload.argsDigest;
+      },
+    ],
+  ])('rejects a signed payload with %s', async (_case, mutate) => {
+    const setup = await setupModern();
+    await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+    const payload = decodeState(setup.requestStates[0]!);
+    mutate(payload);
+    setup.forcedRequestState.value = await sealState(payload);
+    const callCount = setup.calls.length;
+
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('incompatible policy version');
+    expect(setup.calls).toHaveLength(callCount);
+  });
+
+  test('rejects request state after the explicit 120 second TTL', async () => {
+    // Pre-merge security delta: the SDK compares integer Unix seconds, so the
+    // effective expiry boundary is floor-second based. Keep the configured TTL
+    // at exactly 120 seconds and review that SDK boundary as the security delta.
+    let now = Date.now();
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const setup = await setupModern({
+      onContinuation() {
+        now += 121_000;
+      },
+    });
+
+    await expect(
+      setup.client.callTool({ name: 'create_project', arguments: PROJECT_ARGS })
+    ).rejects.toMatchObject({
+      code: -32602,
+      message: 'Invalid or expired requestState',
+    });
+  });
+
+  test('binds state to the actor and tools/call method', async () => {
+    const actor = { value: 'actor-1' };
+    const setup = await setupModern({
+      actor,
+      onContinuation() {
+        actor.value = 'actor-2';
+      },
+    });
+
+    await expect(
+      setup.client.callTool({ name: 'create_project', arguments: PROJECT_ARGS })
+    ).rejects.toMatchObject({
+      code: -32602,
+      message: 'Invalid or expired requestState',
+    });
+    expect(setup.bindMethods).toStrictEqual(['tools/call', 'tools/call']);
+  });
+  test('rejects state under a different method binding', async () => {
+    const methodBinding: { value?: string } = {};
+    const setup = await setupModern({
+      methodBinding,
+      onContinuation() {
+        methodBinding.value = 'prompts/get';
+      },
+    });
+
+    await expect(
+      setup.client.callTool({ name: 'create_project', arguments: PROJECT_ARGS })
+    ).rejects.toMatchObject({
+      code: -32602,
+      message: 'Invalid or expired requestState',
+    });
+    expect(setup.bindMethods).toStrictEqual(['tools/call', 'tools/call']);
+  });
+
+  test('rejects argument drift without creating', async () => {
+    const setup = await setupModern({
+      onContinuation(body) {
+        if (body.params?.arguments !== undefined) {
+          body.params.arguments.name = 'changed-after-prompt';
+        }
+      },
+    });
+
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('arguments changed');
+    expect(setup.calls).not.toContain('create_project');
+  });
+  test('honors the direct kill switch again on redemption', async () => {
+    let enabled = true;
+    const setup = await setupModern({
+      enabled: () => enabled,
+      onContinuation() {
+        enabled = false;
+      },
+    });
+
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('currently unavailable');
+    expect(setup.calls).not.toContain('create_project');
+  });
+
+  test('reports one interactionId across both policy rounds', async () => {
+    const setup = await setupModern();
+
+    await setup.client.callTool({
+      name: 'create_project',
+      arguments: PROJECT_ARGS,
+    });
+
+    await vi.waitFor(() => expect(setup.policyCalls).toHaveLength(2));
+    const ids = setup.policyCalls.map((call) => call.telemetry.interactionId);
+    expect(ids[0]).toEqual(expect.any(String));
+    expect(ids[1]).toBe(ids[0]);
+  });
+  test('hosted readOnly performs no rate read or elicitation', async () => {
+    const setup = await setupModern({ readOnly: true });
+
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: { ...PROJECT_ARGS, confirm_cost_id: 'unused' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('read-only mode');
+    expect(setup.calls).toStrictEqual([]);
+    expect(setup.elicitationRequests).toStrictEqual([]);
+  });
+  test('correlates success text by stable resource identity', () => {
+    const outcome = createCreationOutcomeText<{ ref: string }>(
+      'create_project',
+      (project) => project.ref
+    );
+    const resolution = (amount: number): CostConfirmationResolution => ({
+      maximumCreationRate: { ...PROJECT_RATE, amount },
+    });
+    outcome.record({ ref: 'project-a' }, resolution(10));
+    outcome.record({ ref: 'project-b' }, resolution(5));
+
+    expect(outcome.render({ ref: 'project-b' }, 'second')).toContain('5 USD');
+    expect(outcome.render({ ref: 'project-a' }, 'first')).toContain('10 USD');
+  });
+});
+
+describe('hosted elicitation construction', () => {
+  test.each([
+    'bind',
+    'readProjectCreationRate',
+    'readBranchCreationRate',
+    'enabled',
+    'formDeliveryAvailable',
+  ])('rejects a missing %s dependency', (field) => {
+    const cost = createCostPlatform();
+    const elicitation: Record<string, unknown> = {
+      key: STATE_KEY,
+      bind: (ctx: ServerContext) => `actor-1\0${ctx.mcpReq.method}`,
+      readProjectCreationRate: cost.readProjectCreationRate,
+      readBranchCreationRate: cost.readBranchCreationRate,
+      formDeliveryAvailable: true,
+      enabled: () => true,
+    };
+    delete elicitation[field];
+
+    expect(() =>
+      createSupabaseMcpServer({
+        platform: cost.platform,
+        elicitation,
+      } as unknown as SupabaseMcpServerOptions)
+    ).toThrow(field);
+  });
+
+  test('keeps SDK key validation fail-closed', () => {
+    const cost = createCostPlatform();
+    expect(() =>
+      createSupabaseMcpServer({
+        platform: cost.platform,
+        elicitation: {
+          key: undefined,
+          bind: (ctx: ServerContext) => `actor-1\0${ctx.mcpReq.method}`,
+          readProjectCreationRate: cost.readProjectCreationRate,
+          readBranchCreationRate: cost.readBranchCreationRate,
+          formDeliveryAvailable: true,
+          enabled: () => true,
+        },
+      } as unknown as SupabaseMcpServerOptions)
+    ).toThrow();
+  });
+});
+
+describe('legacy cost compatibility', () => {
+  test('keeps the token schema, suppresses output, and executes the confirmation pair', async () => {
+    const setup = await setupModern({ capabilities: {} });
+    const { tools } = await setup.client.listTools();
+    const createProject = tools.find((tool) => tool.name === 'create_project');
+
+    expect(tools.map((tool) => tool.name)).toContain('confirm_cost');
+    expect(createProject?.inputSchema.required).toContain('confirm_cost_id');
+    expect(createProject?.outputSchema).toBeUndefined();
+
+    const cost = await setup.client.callTool({
+      name: 'get_cost',
+      arguments: { type: 'project', organization_id: 'fixed-org' },
+    });
+    const confirmation = await setup.client.callTool({
+      name: 'confirm_cost',
+      arguments: JSON.parse(textOf(cost)),
+    });
+    const confirmationId = JSON.parse(textOf(confirmation)).confirmation_id;
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: { ...PROJECT_ARGS, confirm_cost_id: confirmationId },
+    });
+
+    expect(result.structuredContent).toBeUndefined();
+    expect(JSON.parse(textOf(result))).toStrictEqual(FIXED_PROJECT);
+  });
+
+  test('drops a supplied legacy token on the form lane', async () => {
+    const setup = await setupModern({ answers: [{ action: 'decline' }] });
+    const result = await setup.client.callTool({
+      name: 'create_project',
+      arguments: { ...PROJECT_ARGS, confirm_cost_id: 'ignored-token' },
+    });
+
+    expect(result.structuredContent).toStrictEqual({ status: 'declined' });
+    expect(setup.elicitationRequests).toHaveLength(1);
+  });
+
+  test('returns migration guidance for direct confirm_cost calls', async () => {
+    const setup = await setupModern();
+    const result = await setup.client.callTool({
+      name: 'confirm_cost',
+      arguments: { type: 'project', recurrence: 'monthly', amount: 10 },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('create_project');
+    expect(textOf(result)).not.toContain('confirmation_id');
+  });
+
+  test.each<[string, SetupOptions]>([
+    ['no form capability', { capabilities: {} }],
+    ['URL-only capability', { capabilities: { elicitation: { url: {} } } }],
+    ['connection opt-out', { optOut: true }],
+    ['unavailable form delivery', { formDeliveryAvailable: false }],
+    ['disabled product switch', { enabled: () => false }],
+  ])('%s keeps the classic contract', async (_case, options) => {
+    const setup = await setupModern(options);
+    const { tools } = await setup.client.listTools();
+    const createProject = tools.find((tool) => tool.name === 'create_project');
+
+    expect(tools.map((tool) => tool.name)).toContain('confirm_cost');
+    expect(createProject?.inputSchema.required).toContain('confirm_cost_id');
+    expect(createProject?.outputSchema).toBeUndefined();
+  });
+
+  test('hosted options on a classic client preserve project and branch bytes', async () => {
+    async function connectClassic(server: Server) {
+      const clientTransport = new StreamTransport();
+      const serverTransport = new StreamTransport();
+      clientTransport.readable.pipeTo(serverTransport.writable);
+      serverTransport.readable.pipeTo(clientTransport.writable);
+      const client = new Client(
+        { name: 'classic-client', version: '1.0.0' },
+        { capabilities: { elicitation: { form: {} } } }
+      );
+      const elicit = vi.fn(async () => ({ action: 'accept' as const }));
+      client.setRequestHandler('elicitation/create', elicit);
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+      return { client, elicit };
+    }
+
+    async function legacyExchange(client: Client) {
+      const projectCost = await client.callTool({
+        name: 'get_cost',
+        arguments: { type: 'project', organization_id: 'fixed-org' },
+      });
+      const projectConfirmation = await client.callTool({
+        name: 'confirm_cost',
+        arguments: JSON.parse(textOf(projectCost)),
+      });
+      const projectConfirmationId = JSON.parse(
+        textOf(projectConfirmation)
+      ).confirmation_id;
+      const projectCreation = await client.callTool({
+        name: 'create_project',
+        arguments: {
+          ...PROJECT_ARGS,
+          confirm_cost_id: projectConfirmationId,
+        },
+      });
+
+      const branchCost = await client.callTool({
+        name: 'get_cost',
+        arguments: { type: 'branch', organization_id: 'fixed-org' },
+      });
+      const branchConfirmation = await client.callTool({
+        name: 'confirm_cost',
+        arguments: JSON.parse(textOf(branchCost)),
+      });
+      const branchConfirmationId = JSON.parse(
+        textOf(branchConfirmation)
+      ).confirmation_id;
+      const branchCreation = await client.callTool({
+        name: 'create_branch',
+        arguments: {
+          ...BRANCH_ARGS,
+          confirm_cost_id: branchConfirmationId,
+        },
+      });
+
+      return {
+        project: {
+          cost: projectCost,
+          confirmation: projectConfirmation,
+          creation: projectCreation,
+        },
+        branch: {
+          cost: branchCost,
+          confirmation: branchConfirmation,
+          creation: branchCreation,
+        },
+      };
+    }
+
+    const baselineCost = createCostPlatform();
+    const baseline = await connectClassic(
+      createSupabaseMcpServer({
+        platform: baselineCost.platform,
+        features: ['account', 'branching'],
+      })
+    );
+    const policyCost = createCostPlatform();
+    const policy = await connectClassic(
+      createSupabaseMcpServer({
+        platform: policyCost.platform,
+        features: ['account', 'branching'],
+        elicitation: {
+          key: STATE_KEY,
+          bind: (ctx) => `actor-1\0${ctx.mcpReq.method}`,
+          readProjectCreationRate: policyCost.readProjectCreationRate,
+          readBranchCreationRate: policyCost.readBranchCreationRate,
+          formDeliveryAvailable: true,
+          enabled: () => true,
+        },
+      })
+    );
+
+    const baselineTools = await baseline.client.listTools();
+    const policyTools = await policy.client.listTools();
+    for (const name of [
+      'get_cost',
+      'confirm_cost',
+      'create_project',
+      'create_branch',
+    ]) {
+      expect(
+        JSON.stringify(policyTools.tools.find((tool) => tool.name === name))
+      ).toBe(
+        JSON.stringify(baselineTools.tools.find((tool) => tool.name === name))
+      );
+    }
+    expect(JSON.stringify(await legacyExchange(policy.client))).toBe(
+      JSON.stringify(await legacyExchange(baseline.client))
+    );
+    expect(policy.elicit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mcp-server-supabase/src/cost-confirmation.test.ts
+++ b/packages/mcp-server-supabase/src/cost-confirmation.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   BRANCH_RATE,
   createCostPlatform,
+  FIXED_BRANCH,
   FIXED_PROJECT,
   PROJECT_RATE,
 } from '../test/cost-platform.js';
@@ -213,6 +214,7 @@ async function sealState(payload: Record<string, unknown>) {
 describe('direct SDK cost confirmation', () => {
   test('accepts an action-only project confirmation with sealed policy state', async () => {
     const setup = await setupModern();
+    await setup.client.listTools();
 
     const result = await setup.client.callTool({
       name: 'create_project',
@@ -245,6 +247,18 @@ describe('direct SDK cost confirmation', () => {
     });
     expect(state.argsDigest).toEqual(expect.any(String));
     expect(state.interactionId).toEqual(expect.any(String));
+  });
+  test('validates an accepted branch against the advertised modern output schema', async () => {
+    const setup = await setupModern();
+    await setup.client.listTools();
+
+    const result = await setup.client.callTool({
+      name: 'create_branch',
+      arguments: BRANCH_ARGS,
+    });
+    expect(result.isError, textOf(result)).not.toBe(true);
+
+    expect(result.structuredContent).toStrictEqual(FIXED_BRANCH);
   });
   test('accept action ignores irrelevant response content', async () => {
     const setup = await setupModern({
@@ -324,6 +338,7 @@ describe('direct SDK cost confirmation', () => {
   test('keeps decline and cancel distinct and creates nothing', async () => {
     for (const action of ['decline', 'cancel'] as const) {
       const setup = await setupModern({ answers: [{ action }] });
+      await setup.client.listTools();
       const result = await setup.client.callTool({
         name: 'create_project',
         arguments: PROJECT_ARGS,
@@ -420,8 +435,14 @@ describe('direct SDK cost confirmation', () => {
       onContinuation(body) {
         const state = body.params?.requestState;
         if (state !== undefined) {
-          const replacement = state.endsWith('x') ? 'y' : 'x';
-          body.params!.requestState = `${state.slice(0, -1)}${replacement}`;
+          const signatureStart = state.lastIndexOf('.') + 1;
+          expect(signatureStart).toBeGreaterThan(0);
+          const signatureChar = state[signatureStart];
+          expect(signatureChar).toEqual(expect.any(String));
+          const replacement = signatureChar === 'A' ? 'B' : 'A';
+          const tampered = `${state.slice(0, signatureStart)}${replacement}${state.slice(signatureStart + 1)}`;
+          expect(tampered).not.toBe(state);
+          body.params!.requestState = tampered;
         }
       },
     });

--- a/packages/mcp-server-supabase/src/cost-confirmation.ts
+++ b/packages/mcp-server-supabase/src/cost-confirmation.ts
@@ -1,0 +1,551 @@
+import {
+  createRequestStateCodec,
+  inputRequired,
+  inputResponse,
+  type CallToolResult,
+  type RequestStateCodec,
+  type ServerContext,
+  type ServerOptions,
+} from '@modelcontextprotocol/server';
+import type {
+  ToolPolicy,
+  ToolPolicyDecision,
+  ToolPolicyTelemetry,
+  ToolRequestContext,
+} from '@supabase/mcp-utils';
+import { z } from 'zod/v4';
+
+import { createElicitationToolPolicy } from './elicitation-tool-policy.js';
+import { canonicalObjectDigest } from './object-digest.js';
+
+export const APPROVED_RATE_STALE = 'approved_rate_stale';
+const COST_CONFIRMATION_POLICY_ID = 'supabase.cost_confirmation';
+const POLICY_VERSION = 2;
+const REQUEST_STATE_VERSION = 1;
+const REQUEST_STATE_TTL_SECONDS = 120;
+const CONSENT_REQUEST = 'cost_confirmation';
+export const LEGACY_CONFIRMATION_FIELD = 'confirm_cost_id';
+
+const MIGRATION_GUIDANCE =
+  'This client confirms costs inside the tool that creates the resource. Call create_project or create_branch directly and answer the confirmation it requests; a separate confirmation ID is not needed.';
+const creationRateSchema = z
+  .object({
+    amount: z.number().finite().nonnegative(),
+    currency: z.string().min(1),
+    recurrence: z.enum(['hourly', 'monthly']),
+  })
+  .strict();
+
+export type CreationRate = {
+  amount: number;
+  currency: string;
+  recurrence: 'hourly' | 'monthly';
+};
+
+export type CostConfirmationResolution = {
+  maximumCreationRate: CreationRate;
+};
+
+type CostConfirmationTool = 'create_project' | 'create_branch';
+
+type CostConfirmationSubject = {
+  resourceName: string;
+  account:
+    | { type: 'organization'; id: string }
+    | { type: 'parent_project'; id: string };
+};
+
+const costConfirmationStateSchema = z
+  .object({
+    v: z.literal(REQUEST_STATE_VERSION),
+    policy: z.literal(COST_CONFIRMATION_POLICY_ID),
+    policyVersion: z.literal(POLICY_VERSION),
+    tool: z.enum(['create_project', 'create_branch']),
+    argsDigest: z.string().min(1),
+    approvedRate: creationRateSchema,
+    interactionId: z.string().uuid(),
+  })
+  .strict();
+
+type CostConfirmationState = z.infer<typeof costConfirmationStateSchema>;
+
+type CostConfirmationPolicyOptions<Args> = {
+  tool: CostConfirmationTool;
+  canonicalArguments(args: Args): Record<string, unknown>;
+  subject(args: Args): CostConfirmationSubject;
+  readRate(args: Args): Promise<CreationRate>;
+};
+
+export type CostConfirmationOptions = {
+  key: string | Uint8Array;
+  bind(ctx: ServerContext): string;
+  formDeliveryAvailable?: boolean;
+  optOut?: boolean;
+  enabled?: (ctx: ToolRequestContext) => boolean;
+};
+
+export type CostConfirmation = {
+  requestState: NonNullable<ServerOptions['requestState']>;
+  capable(ctx: ToolRequestContext): boolean;
+  policy<Args>(
+    options: CostConfirmationPolicyOptions<Args>
+  ): ToolPolicy<Args, CostConfirmationResolution | undefined>;
+  legacyConfirmationPolicy: ToolPolicy<unknown, undefined>;
+};
+
+function rateStatement(rate: CreationRate): string {
+  const interval = rate.recurrence === 'hourly' ? 'per hour' : 'per month';
+  return `${rate.amount} ${rate.currency} ${interval}`;
+}
+
+function confirmationMessage(
+  tool: CostConfirmationTool,
+  subject: CostConfirmationSubject,
+  rate: CreationRate
+): string {
+  const resource = tool === 'create_project' ? 'project' : 'branch';
+  const where =
+    subject.account.type === 'organization'
+      ? `in organization ${subject.account.id}`
+      : `on project ${subject.account.id}`;
+
+  return [
+    `Creating the ${resource} "${subject.resourceName}" ${where}`,
+    `adds ${rateStatement(rate)}, and that charge recurs until the ${resource} is deleted.`,
+    'Accept to create it now, or decline to leave it uncreated.',
+  ].join(' ');
+}
+
+function terminalMessage(
+  tool: CostConfirmationTool,
+  outcome: 'declined' | 'cancelled'
+): string {
+  const resource = tool === 'create_project' ? 'project' : 'branch';
+  const reported =
+    outcome === 'declined'
+      ? 'The client reported that the cost was declined'
+      : 'The client dismissed the request without answering it';
+  return `${reported}, so no ${resource} was created.`;
+}
+
+function terminalResult(
+  status: 'declined' | 'cancelled',
+  message: string
+): CallToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    structuredContent: { status },
+  };
+}
+
+function errorResult(message: string): CallToolResult {
+  return { isError: true, content: [{ type: 'text', text: message }] };
+}
+
+function withTerminalOutput(schema: z.ZodObject<any>) {
+  const terminal = z.enum(['declined', 'cancelled']);
+  const businessStatus = (schema.shape as Record<string, z.ZodType>).status;
+  const root = schema.partial().extend({
+    status:
+      businessStatus === undefined
+        ? terminal.optional()
+        : z.union([businessStatus, terminal]).optional(),
+  });
+
+  return root.superRefine((value, ctx) => {
+    const business = schema.safeParse(value);
+    if (business.success) {
+      return;
+    }
+    const record = value as Record<string, unknown>;
+    if (terminal.safeParse(record.status).success) {
+      for (const key of Object.keys(record)) {
+        if (key !== 'status') {
+          ctx.addIssue({
+            code: 'custom',
+            path: [key],
+            message: 'Unexpected field on a terminal result.',
+          });
+        }
+      }
+      return;
+    }
+    for (const issue of business.error.issues) {
+      ctx.addIssue({ ...issue });
+    }
+  });
+}
+
+function formCapable(ctx: ToolRequestContext): boolean {
+  if (ctx.era !== 'modern') {
+    return false;
+  }
+  const elicitation = ctx.clientCapabilities?.elicitation;
+  if (elicitation === undefined) {
+    return false;
+  }
+  return (
+    elicitation.form !== undefined ||
+    (elicitation.form === undefined && elicitation.url === undefined)
+  );
+}
+
+function telemetry(
+  outcome: string,
+  interactionId?: string,
+  reason?: string
+): ToolPolicyTelemetry {
+  return {
+    policyId: COST_CONFIRMATION_POLICY_ID,
+    policyVersion: POLICY_VERSION,
+    outcome,
+    interactionId,
+    authorityPath: 'sdk_input_required',
+    reason,
+  };
+}
+
+function parseState(
+  state: unknown,
+  tool: CostConfirmationTool
+): CostConfirmationState | undefined {
+  const parsed = costConfirmationStateSchema.safeParse(state);
+  return parsed.success && parsed.data.tool === tool ? parsed.data : undefined;
+}
+
+async function argumentsDigest(value: Record<string, unknown>) {
+  return canonicalObjectDigest(value);
+}
+
+function createPolicy<Args>(
+  codec: RequestStateCodec<unknown>,
+  capable: (ctx: ToolRequestContext) => boolean,
+  enabled: (ctx: ToolRequestContext) => boolean,
+  options: CostConfirmationPolicyOptions<Args>
+): ToolPolicy<Args, CostConfirmationResolution | undefined> {
+  const owns = (ctx: ToolRequestContext) =>
+    ctx.server.mcpReq.requestState<CostConfirmationState>() !== undefined ||
+    capable(ctx);
+  async function staleRateDecision(
+    args: Args,
+    approvedRate: CreationRate,
+    interactionId: string
+  ): Promise<ToolPolicyDecision<
+    CostConfirmationResolution | undefined
+  > | null> {
+    const finalRate = creationRateSchema.safeParse(
+      await options.readRate(args)
+    );
+    if (!finalRate.success) {
+      return {
+        type: 'result',
+        result: errorResult(
+          'The authoritative cost response was invalid, so nothing was created. Run the tool again.'
+        ),
+        telemetry: telemetry(
+          'rejected',
+          interactionId,
+          'invalid_authoritative_rate'
+        ),
+      };
+    }
+    try {
+      assertRateStillApproved(finalRate.data, approvedRate);
+      return null;
+    } catch (error) {
+      return {
+        type: 'result',
+        result: errorResult(
+          error instanceof Error
+            ? error.message
+            : `The authoritative cost changed (${APPROVED_RATE_STALE}), so nothing was created. Run the tool again.`
+        ),
+        telemetry: telemetry('rejected', interactionId, APPROVED_RATE_STALE),
+      };
+    }
+  }
+
+  return createElicitationToolPolicy<
+    Args,
+    unknown,
+    CostConfirmationResolution | undefined
+  >({
+    inputSchema(schema, ctx) {
+      return owns(ctx)
+        ? schema.omit({ [LEGACY_CONFIRMATION_FIELD]: true })
+        : schema;
+    },
+
+    outputSchema(schema, ctx) {
+      return owns(ctx) ? withTerminalOutput(schema) : undefined;
+    },
+
+    normalizeArguments(raw, ctx) {
+      if (!owns(ctx) || raw === null || typeof raw !== 'object') {
+        return raw;
+      }
+      const { [LEGACY_CONFIRMATION_FIELD]: _ignored, ...business } =
+        raw as Record<string, unknown>;
+      return business;
+    },
+
+    async resolve(args, ctx, round) {
+      if (!owns(ctx)) {
+        return {
+          type: 'execute',
+          resolution: undefined,
+          telemetry: {
+            ...telemetry('executed'),
+            authorityPath: 'legacy_confirmation',
+          },
+        };
+      }
+
+      if (round.requestState === undefined) {
+        const parsedRate = creationRateSchema.safeParse(
+          await options.readRate(args)
+        );
+        if (!parsedRate.success) {
+          return {
+            type: 'result',
+            result: errorResult(
+              'The authoritative cost response was invalid, so nothing was created. Run the tool again.'
+            ),
+            telemetry: telemetry(
+              'rejected',
+              undefined,
+              'invalid_authoritative_rate'
+            ),
+          };
+        }
+        const rate = parsedRate.data;
+        const interactionId = crypto.randomUUID();
+        if (rate.amount === 0) {
+          const stale = await staleRateDecision(args, rate, interactionId);
+          if (stale !== null) {
+            return stale;
+          }
+          return {
+            type: 'execute',
+            resolution: { maximumCreationRate: rate },
+            telemetry: telemetry('executed', interactionId, 'zero_rate'),
+          };
+        }
+
+        const state: CostConfirmationState = {
+          v: REQUEST_STATE_VERSION,
+          policy: COST_CONFIRMATION_POLICY_ID,
+          policyVersion: POLICY_VERSION,
+          tool: options.tool,
+          argsDigest: await argumentsDigest(options.canonicalArguments(args)),
+          approvedRate: rate,
+          interactionId,
+        };
+        return {
+          type: 'inputRequired',
+          inputRequests: {
+            [CONSENT_REQUEST]: inputRequired.elicit({
+              message: confirmationMessage(
+                options.tool,
+                options.subject(args),
+                rate
+              ),
+              requestedSchema: { type: 'object', properties: {} },
+            }),
+          },
+          requestState: await codec.mint(state, ctx.server),
+          telemetry: telemetry('input_required', interactionId),
+        };
+      }
+
+      const state = parseState(round.requestState, options.tool);
+      if (state === undefined) {
+        return {
+          type: 'result',
+          result: errorResult(
+            'This cost confirmation was issued by an incompatible policy version, so nothing was created. Run the tool again.'
+          ),
+          telemetry: telemetry('rejected', undefined, 'invalid_state_payload'),
+        };
+      }
+
+      if (
+        state.argsDigest !==
+        (await argumentsDigest(options.canonicalArguments(args)))
+      ) {
+        return {
+          type: 'result',
+          result: errorResult(
+            'The tool arguments changed after cost confirmation started, so nothing was created. Run the tool again.'
+          ),
+          telemetry: telemetry(
+            'rejected',
+            state.interactionId,
+            'arguments_changed'
+          ),
+        };
+      }
+
+      if (!enabled(ctx)) {
+        return {
+          type: 'result',
+          result: errorResult(
+            'Cost confirmation is currently unavailable, so nothing was created. Run the tool again later.'
+          ),
+          telemetry: telemetry('rejected', state.interactionId, 'kill_switch'),
+        };
+      }
+
+      const answer = inputResponse(round.inputResponses, CONSENT_REQUEST);
+      if (answer.kind !== 'elicit') {
+        return {
+          type: 'result',
+          result: errorResult(
+            'The client returned no answer to the cost confirmation, so nothing was created. Run the tool again.'
+          ),
+          telemetry: telemetry(
+            'rejected',
+            state.interactionId,
+            'missing_response'
+          ),
+        };
+      }
+
+      switch (answer.action) {
+        case 'accept': {
+          const stale = await staleRateDecision(
+            args,
+            state.approvedRate,
+            state.interactionId
+          );
+          if (stale !== null) {
+            return stale;
+          }
+          return {
+            type: 'execute',
+            resolution: { maximumCreationRate: state.approvedRate },
+            telemetry: telemetry('accepted', state.interactionId),
+          };
+        }
+        case 'decline':
+          return {
+            type: 'result',
+            result: terminalResult(
+              'declined',
+              terminalMessage(options.tool, 'declined')
+            ),
+            telemetry: telemetry('declined', state.interactionId),
+          };
+        case 'cancel':
+          return {
+            type: 'result',
+            result: terminalResult(
+              'cancelled',
+              terminalMessage(options.tool, 'cancelled')
+            ),
+            telemetry: telemetry('cancelled', state.interactionId),
+          };
+      }
+    },
+  });
+}
+
+export function createCostConfirmation(
+  options: CostConfirmationOptions
+): CostConfirmation {
+  const codec = createRequestStateCodec<unknown>({
+    key: options.key,
+    ttlSeconds: REQUEST_STATE_TTL_SECONDS,
+    bind: options.bind,
+  });
+  const enabled = options.enabled ?? (() => true);
+  const capable = (ctx: ToolRequestContext) =>
+    options.formDeliveryAvailable === true &&
+    options.optOut !== true &&
+    enabled(ctx) &&
+    formCapable(ctx);
+
+  return {
+    requestState: { verify: codec.verify },
+    capable,
+    policy: (policyOptions) =>
+      createPolicy(codec, capable, enabled, policyOptions),
+    legacyConfirmationPolicy: {
+      outputSchema: (schema, ctx) => (capable(ctx) ? schema : undefined),
+      async resolve(_args, ctx): Promise<ToolPolicyDecision<undefined>> {
+        if (capable(ctx)) {
+          return {
+            type: 'result',
+            result: errorResult(MIGRATION_GUIDANCE),
+            telemetry: {
+              ...telemetry(
+                'rejected',
+                undefined,
+                'legacy_confirmation_retired'
+              ),
+              authorityPath: 'legacy_confirmation',
+            },
+          };
+        }
+        return {
+          type: 'execute',
+          resolution: undefined,
+          telemetry: {
+            ...telemetry('executed'),
+            authorityPath: 'legacy_confirmation',
+          },
+        };
+      },
+    },
+  };
+}
+
+export function assertRateStillApproved(
+  rate: CreationRate,
+  approved: CreationRate
+): void {
+  if (
+    rate.currency === approved.currency &&
+    rate.recurrence === approved.recurrence &&
+    rate.amount <= approved.amount
+  ) {
+    return;
+  }
+  throw new Error(
+    `The authoritative cost changed after it was approved (${APPROVED_RATE_STALE}), so nothing was created. Run the tool again to review the current cost.`
+  );
+}
+
+export function creationOutcomeMessage(
+  tool: CostConfirmationTool,
+  resourceName: string,
+  approved: CreationRate
+): string {
+  const resource = tool === 'create_project' ? 'project' : 'branch';
+  if (approved.amount === 0) {
+    return `The authoritative rate for this ${resource} is ${rateStatement(approved)}, so no confirmation was requested. The ${resource} "${resourceName}" was created.`;
+  }
+  return `The client reported that ${rateStatement(approved)} was accepted. The ${resource} "${resourceName}" was created.`;
+}
+
+export function createCreationOutcomeText<Result extends object>(
+  tool: CostConfirmationTool,
+  identity: (result: Result) => string
+) {
+  const approved = new Map<string, CreationRate>();
+  return {
+    record(result: Result, resolution: CostConfirmationResolution | undefined) {
+      if (resolution !== undefined) {
+        approved.set(identity(result), resolution.maximumCreationRate);
+      }
+    },
+    render(result: Result, resourceName: string) {
+      const key = identity(result);
+      const rate = approved.get(key);
+      approved.delete(key);
+      return rate === undefined
+        ? JSON.stringify(result)
+        : creationOutcomeMessage(tool, resourceName, rate);
+    },
+  };
+}

--- a/packages/mcp-server-supabase/src/cost-confirmation.ts
+++ b/packages/mcp-server-supabase/src/cost-confirmation.ts
@@ -145,12 +145,15 @@ function errorResult(message: string): CallToolResult {
 function withTerminalOutput(schema: z.ZodObject<any>) {
   const terminal = z.enum(['declined', 'cancelled']);
   const businessStatus = (schema.shape as Record<string, z.ZodType>).status;
-  const root = schema.partial().extend({
-    status:
-      businessStatus === undefined
-        ? terminal.optional()
-        : z.union([businessStatus, terminal]).optional(),
-  });
+  const root = schema
+    .partial()
+    .extend({
+      status:
+        businessStatus === undefined
+          ? terminal.optional()
+          : z.union([businessStatus, terminal]).optional(),
+    })
+    .loose();
 
   return root.superRefine((value, ctx) => {
     const business = schema.safeParse(value);

--- a/packages/mcp-server-supabase/src/elicitation-tool-policy.test.ts
+++ b/packages/mcp-server-supabase/src/elicitation-tool-policy.test.ts
@@ -1,0 +1,283 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import {
+  createMcpHandler,
+  inputRequired,
+  type ElicitResult,
+  type McpHttpHandler,
+} from '@modelcontextprotocol/server';
+import { createMcpServer, StreamTransport, tool } from '@supabase/mcp-utils';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { z } from 'zod/v4';
+
+import { createElicitationToolPolicy } from './elicitation-tool-policy.js';
+
+const MODERN_PROTOCOL_VERSION = '2026-07-28';
+const CLASSIC_PROTOCOL_VERSION = '2025-06-18';
+const MCP_ENDPOINT = new URL('https://mcp.test');
+const telemetry = {
+  policyId: 'fixture-policy',
+  policyVersion: 1,
+  outcome: 'allowed',
+};
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup();
+  }
+});
+
+async function connectClient(
+  protocolVersion: string,
+  handler: McpHttpHandler,
+  capabilities: Record<string, unknown> = {}
+) {
+  const transport = new StreamableHTTPClientTransport(MCP_ENDPOINT, {
+    fetch: (url, init) => handler.fetch(new Request(url, init)),
+  });
+  const client = new Client(
+    { name: 'elicitation-policy-fixture', version: '0.0.0' },
+    {
+      capabilities,
+      supportedProtocolVersions: [protocolVersion],
+      versionNegotiation:
+        protocolVersion === MODERN_PROTOCOL_VERSION
+          ? { mode: { pin: protocolVersion } }
+          : { mode: 'legacy' },
+    }
+  );
+
+  await client.connect(transport);
+  cleanups.push(
+    () => client.close(),
+    () => handler.close()
+  );
+  return client;
+}
+
+describe('createElicitationToolPolicy', () => {
+  test('carries form and elicitUrl shapes through mcp-utils and returns re-entry transport values', async () => {
+    const elicitationRequests: unknown[] = [];
+    const rounds: unknown[] = [];
+    const handler = createMcpHandler(
+      () =>
+        createMcpServer({
+          name: 'elicitation-policy-fixture',
+          version: '0.0.0',
+          requestState: {
+            verify: async (state) => {
+              expect(state).toBe('fixture-state');
+              return { verified: true };
+            },
+          },
+          tools: {
+            guarded: tool({
+              description: 'Guarded',
+              parameters: z.object({ value: z.string() }),
+              outputSchema: z.object({ value: z.string() }),
+              policy: createElicitationToolPolicy<
+                { value: string },
+                { verified: boolean },
+                undefined
+              >({
+                async resolve(_params, _ctx, round) {
+                  rounds.push(round);
+                  if (round.requestState === undefined) {
+                    return {
+                      type: 'inputRequired',
+                      inputRequests: {
+                        confirm: inputRequired.elicit({
+                          message: 'Confirm the action',
+                          requestedSchema: {
+                            type: 'object',
+                            properties: {},
+                          },
+                        }),
+                        handoff: inputRequired.elicitUrl({
+                          message: 'Complete the handoff',
+                          url: 'https://example.com/handoff',
+                        }),
+                      },
+                      requestState: 'fixture-state',
+                      telemetry,
+                    };
+                  }
+
+                  return {
+                    type: 'execute',
+                    resolution: undefined,
+                    telemetry,
+                  };
+                },
+              }),
+              execute: async ({ value }) => ({ value }),
+            }),
+          },
+        }),
+      { legacy: 'reject' }
+    );
+    const client = await connectClient(MODERN_PROTOCOL_VERSION, handler, {
+      elicitation: { form: {}, url: {} },
+    });
+    client.setRequestHandler('elicitation/create', async (request) => {
+      elicitationRequests.push(request.params);
+      return { action: 'accept' } satisfies ElicitResult;
+    });
+
+    const result = await client.callTool({
+      name: 'guarded',
+      arguments: { value: 'done' },
+    });
+
+    expect(elicitationRequests).toEqual(
+      expect.arrayContaining([
+        {
+          mode: 'form',
+          message: 'Confirm the action',
+          requestedSchema: { type: 'object', properties: {} },
+        },
+        {
+          mode: 'url',
+          message: 'Complete the handoff',
+          url: 'https://example.com/handoff',
+        },
+      ])
+    );
+    expect(rounds).toHaveLength(2);
+    expect(rounds[0]).toStrictEqual({
+      requestState: undefined,
+      inputResponses: undefined,
+    });
+    expect(rounds[1]).toStrictEqual({
+      requestState: { verified: true },
+      inputResponses: {
+        confirm: { action: 'accept' },
+        handoff: { action: 'accept' },
+      },
+    });
+    expect(result.structuredContent).toStrictEqual({ value: 'done' });
+  });
+
+  test('the enabled legacyShim default re-enters while classic lane selection keeps confirm_cost', async () => {
+    const elicit = vi.fn(async () => ({ action: 'accept' as const }));
+    const shimRounds: unknown[] = [];
+    const server = createMcpServer({
+      name: 'classic-policy-fixture',
+      version: '0.0.0',
+      tools: {
+        create_project: tool({
+          description: 'Create project',
+          parameters: z.object({
+            name: z.string(),
+            confirm_cost: z.boolean().optional(),
+          }),
+          outputSchema: z.object({ name: z.string() }),
+          policy: createElicitationToolPolicy<
+            { name: string; confirm_cost?: boolean },
+            unknown,
+            undefined
+          >({
+            inputSchema: (schema, ctx) => {
+              expect(ctx.era).toBe('legacy');
+              return schema;
+            },
+            async resolve(params, ctx) {
+              expect(ctx.era).toBe('legacy');
+              expect(params.confirm_cost).toBe(true);
+              return {
+                type: 'execute',
+                resolution: undefined,
+                telemetry,
+              };
+            },
+          }),
+          execute: async ({ name }) => ({ name }),
+        }),
+        shim_probe: tool({
+          description: 'Probe the SDK legacy shim',
+          parameters: z.object({ value: z.string() }),
+          outputSchema: z.object({ value: z.string() }),
+          policy: createElicitationToolPolicy<
+            { value: string },
+            string,
+            undefined
+          >({
+            async resolve(_params, _ctx, round) {
+              shimRounds.push(round);
+              if (round.requestState === undefined) {
+                return {
+                  type: 'inputRequired',
+                  inputRequests: {
+                    confirm: inputRequired.elicit({
+                      message: 'Confirm the shim round',
+                      requestedSchema: {
+                        type: 'object',
+                        properties: {},
+                      },
+                    }),
+                  },
+                  requestState: 'classic-shim-state',
+                  telemetry,
+                };
+              }
+
+              return {
+                type: 'execute',
+                resolution: undefined,
+                telemetry,
+              };
+            },
+          }),
+          execute: async ({ value }) => ({ value }),
+        }),
+      },
+    });
+    const clientTransport = new StreamTransport();
+    const serverTransport = new StreamTransport();
+    clientTransport.readable.pipeTo(serverTransport.writable);
+    serverTransport.readable.pipeTo(clientTransport.writable);
+    const client = new Client(
+      { name: 'classic-policy-fixture', version: '0.0.0' },
+      {
+        capabilities: { elicitation: {} },
+        supportedProtocolVersions: [CLASSIC_PROTOCOL_VERSION],
+        versionNegotiation: { mode: 'legacy' },
+      }
+    );
+    client.setRequestHandler('elicitation/create', elicit);
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const tools = await client.listTools();
+    const result = await client.callTool({
+      name: 'create_project',
+      arguments: { name: 'classic', confirm_cost: true },
+    });
+
+    expect(tools.tools[0]?.inputSchema).toMatchObject({
+      properties: { confirm_cost: { type: 'boolean' } },
+    });
+    expect(result.content).toStrictEqual([
+      { type: 'text', text: JSON.stringify({ name: 'classic' }) },
+    ]);
+    expect(elicit).not.toHaveBeenCalled();
+
+    const shimResult = await client.callTool({
+      name: 'shim_probe',
+      arguments: { value: 're-entered' },
+    });
+
+    expect(shimRounds).toStrictEqual([
+      { requestState: undefined, inputResponses: undefined },
+      {
+        requestState: 'classic-shim-state',
+        inputResponses: { confirm: { action: 'accept' } },
+      },
+    ]);
+    expect(elicit).toHaveBeenCalledTimes(1);
+    expect(shimResult.structuredContent).toStrictEqual({ value: 're-entered' });
+  });
+});

--- a/packages/mcp-server-supabase/src/elicitation-tool-policy.ts
+++ b/packages/mcp-server-supabase/src/elicitation-tool-policy.ts
@@ -1,0 +1,74 @@
+import { inputRequired } from '@modelcontextprotocol/server';
+import type {
+  ToolPolicy,
+  ToolPolicyDecision,
+  ToolPolicyTelemetry,
+  ToolRequestContext,
+} from '@supabase/mcp-utils';
+
+/** Input requests accepted by the SDK's multi-round-trip result builder. */
+type InputRequests = NonNullable<
+  Parameters<typeof inputRequired>[0]['inputRequests']
+>;
+
+/** Transport values available when the SDK re-enters the policy. */
+type ElicitationRound<RequestState> = {
+  /** Policy state after the server's request-state verifier accepts it. */
+  requestState: RequestState | undefined;
+  /** Client responses to the policy's prior input requests. */
+  inputResponses: ToolRequestContext['server']['mcpReq']['inputResponses'];
+};
+
+/** A policy-authored request for another SDK multi-round trip. */
+type ElicitationRequired = {
+  type: 'inputRequired';
+  inputRequests: InputRequests;
+  requestState: string;
+  telemetry: ToolPolicyTelemetry;
+};
+
+/**
+ * Private author contract for policies that use SDK multi-round trips.
+ *
+ * The policy owns every product decision and all request-state persistence.
+ * This adapter only translates its input request into the SDK result shape and
+ * returns the SDK's verified state and input responses on the next round.
+ */
+type ElicitationToolPolicy<Params, RequestState, Resolution> = Omit<
+  ToolPolicy<Params, Resolution>,
+  'resolve'
+> & {
+  resolve(
+    params: Params,
+    ctx: ToolRequestContext,
+    round: ElicitationRound<RequestState>
+  ): Promise<ToolPolicyDecision<Resolution> | ElicitationRequired>;
+};
+
+/** Mounts a private elicitation author contract on mcp-utils' ToolPolicy seam. */
+export function createElicitationToolPolicy<Params, RequestState, Resolution>(
+  policy: ElicitationToolPolicy<Params, RequestState, Resolution>
+): ToolPolicy<Params, Resolution> {
+  return {
+    ...policy,
+    async resolve(params, ctx) {
+      const decision = await policy.resolve(params, ctx, {
+        requestState: ctx.server.mcpReq.requestState<RequestState>(),
+        inputResponses: ctx.server.mcpReq.inputResponses,
+      });
+
+      if (decision.type !== 'inputRequired') {
+        return decision;
+      }
+
+      return {
+        type: 'result',
+        result: inputRequired({
+          inputRequests: decision.inputRequests,
+          requestState: decision.requestState,
+        }),
+        telemetry: decision.telemetry,
+      };
+    },
+  };
+}

--- a/packages/mcp-server-supabase/src/object-digest.ts
+++ b/packages/mcp-server-supabase/src/object-digest.ts
@@ -1,0 +1,22 @@
+export async function canonicalObjectDigest(
+  value: Record<string, unknown>,
+  length?: number
+): Promise<string> {
+  const canonical = JSON.stringify(value, (_, nested) => {
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      return Object.keys(nested)
+        .sort()
+        .reduce<Record<string, unknown>>((result, key) => {
+          result[key] = (nested as Record<string, unknown>)[key];
+          return result;
+        }, {});
+    }
+    return nested;
+  });
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(canonical)
+  );
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+  return base64.slice(0, length);
+}

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -1,9 +1,14 @@
+import type { ServerContext } from '@modelcontextprotocol/server';
 import {
   createMcpServer,
   type Tool,
   type ToolCallCallback,
 } from '@supabase/mcp-utils';
 import packageJson from '../package.json' with { type: 'json' };
+import {
+  createCostConfirmation,
+  type CreationRate,
+} from './cost-confirmation.js';
 import { createContentApiClient } from './content-api/index.js';
 import type { SupabasePlatform } from './platform/types.js';
 import { getAccountTools } from './tools/account-tools.js';
@@ -19,6 +24,64 @@ import type { FeatureGroup } from './types.js';
 import { parseFeatureGroups } from './util.js';
 
 const { version } = packageJson;
+type HostedPolicyCallDetails = {
+  name: string;
+  decision: 'execute' | 'result' | 'rejected';
+  clientInfo?: { name: string; version: string; title?: string };
+  durationMs: number;
+  telemetry: {
+    policyId?: string;
+    policyVersion?: number;
+    outcome?: string;
+    interactionId?: string;
+    authorityPath?: string;
+    reason?: string;
+  };
+};
+
+type HostedElicitationOptions = {
+  /** Shared SDK request-state HMAC key, at least 32 bytes. */
+  key: string | Uint8Array;
+  /** Binds request state to the authenticated actor and MCP method. */
+  bind(ctx: ServerContext): string;
+  /** Reads the authoritative project creation rate outside SupabasePlatform. */
+  readProjectCreationRate(organizationId: string): Promise<CreationRate>;
+  /** Reads the authoritative branch creation rate outside SupabasePlatform. */
+  readBranchCreationRate(projectId: string): Promise<CreationRate>;
+  /** Whether this serving path can deliver form input requests. */
+  formDeliveryAvailable: boolean;
+  /** Direct product kill switch, checked at proposal and redemption time. */
+  enabled(): boolean;
+  /** Connection-level form elicitation opt-out. */
+  optOut?: boolean;
+  /** Callback for each allowlisted cost-policy decision. */
+  onToolPolicyCall?: (details: HostedPolicyCallDetails) => void | Promise<void>;
+};
+function assertHostedElicitationOptions(
+  value: unknown
+): asserts value is HostedElicitationOptions {
+  if (value === null || typeof value !== 'object') {
+    throw new TypeError('Hosted elicitation options must be an object.');
+  }
+  const options = value as Record<string, unknown>;
+  for (const field of [
+    'bind',
+    'readProjectCreationRate',
+    'readBranchCreationRate',
+    'enabled',
+  ]) {
+    if (typeof options[field] !== 'function') {
+      throw new TypeError(
+        `Hosted elicitation option "${field}" must be a function.`
+      );
+    }
+  }
+  if (typeof options.formDeliveryAvailable !== 'boolean') {
+    throw new TypeError(
+      'Hosted elicitation option "formDeliveryAvailable" must be a boolean.'
+    );
+  }
+}
 
 export type SupabaseMcpServerOptions = {
   /**
@@ -49,6 +112,14 @@ export type SupabaseMcpServerOptions = {
    * Options: 'account', 'branching', 'database', 'debugging', 'development', 'docs', 'functions', 'storage'
    */
   features?: string[];
+  /**
+   * Hosted cost-confirmation integration.
+   *
+   * Omit this block for classic, local, and stdio serving. When present, all
+   * security dependencies are required: state integrity and actor/method
+   * binding, authoritative rate readers, form delivery, and the kill switch.
+   */
+  elicitation?: HostedElicitationOptions;
 
   /**
    * Callback for after a supabase tool is called.
@@ -86,7 +157,7 @@ If you are running in a web-only or remote environment without filesystem or she
 `.trim();
 
 /**
- * Creates an MCP server for interacting with Supabase.
+ * Creates an MCP server for Supabase.
  */
 export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
   const {
@@ -95,9 +166,24 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     readOnly,
     features,
     contentApiUrl = 'https://supabase.com/docs/api/graphql',
+    elicitation: elicitationOptions,
     onToolCall,
   } = options;
+  if (elicitationOptions !== undefined) {
+    assertHostedElicitationOptions(elicitationOptions);
+  }
+  const onToolPolicyCall = elicitationOptions?.onToolPolicyCall;
 
+  const costConfirmation =
+    elicitationOptions === undefined
+      ? undefined
+      : createCostConfirmation({
+          key: elicitationOptions.key,
+          bind: elicitationOptions.bind,
+          formDeliveryAvailable: elicitationOptions.formDeliveryAvailable,
+          optOut: elicitationOptions.optOut,
+          enabled: () => elicitationOptions.enabled(),
+        });
   const contentApiClientPromise = createContentApiClient(contentApiUrl, {
     'User-Agent': `supabase-mcp/${version}`,
   });
@@ -133,6 +219,8 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         ),
       ]);
     },
+    requestState: costConfirmation?.requestState,
+    onToolPolicyCall,
     onToolCall,
     tools: async () => {
       const contentApiClient = await contentApiClientPromise;
@@ -153,7 +241,21 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       }
 
       if (!projectId && account && enabledFeatures.has('account')) {
-        Object.assign(tools, getAccountTools({ account, readOnly }));
+        Object.assign(
+          tools,
+          getAccountTools({
+            account,
+            readOnly,
+            elicitation:
+              costConfirmation === undefined || elicitationOptions === undefined
+                ? undefined
+                : {
+                    costConfirmation,
+                    readProjectCreationRate:
+                      elicitationOptions.readProjectCreationRate,
+                  },
+          })
+        );
       }
 
       if (database && enabledFeatures.has('database')) {
@@ -185,7 +287,19 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       if (branching && enabledFeatures.has('branching')) {
         Object.assign(
           tools,
-          getBranchingTools({ branching, projectId, readOnly })
+          getBranchingTools({
+            branching,
+            projectId,
+            readOnly,
+            elicitation:
+              costConfirmation === undefined || elicitationOptions === undefined
+                ? undefined
+                : {
+                    costConfirmation,
+                    readBranchCreationRate:
+                      elicitationOptions.readBranchCreationRate,
+                  },
+          })
         );
       }
 

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -1,6 +1,12 @@
 import { tool } from '@supabase/mcp-utils';
 import { z } from 'zod/v4';
 import type { ToolDefs } from './util.js';
+import {
+  type CostConfirmation,
+  type CostConfirmationResolution,
+  createCreationOutcomeText,
+  type CreationRate,
+} from '../cost-confirmation.js';
 import type { AccountOperations } from '../platform/types.js';
 import { organizationSchema, projectSchema } from '../platform/types.js';
 import { getBranchCost, getNextProjectCost } from '../pricing.js';
@@ -10,6 +16,10 @@ import { hashObject } from '../util.js';
 type AccountToolsOptions = {
   account: AccountOperations;
   readOnly?: boolean;
+  elicitation?: {
+    costConfirmation: CostConfirmation;
+    readProjectCreationRate(organizationId: string): Promise<CreationRate>;
+  };
 };
 
 const listOrganizationsInputSchema = z.object({});
@@ -215,7 +225,31 @@ export const accountToolDefs = {
   },
 } as const satisfies ToolDefs;
 
-export function getAccountTools({ account, readOnly }: AccountToolsOptions) {
+export function getAccountTools({
+  account,
+  readOnly,
+  elicitation,
+}: AccountToolsOptions) {
+  const costConfirmation = readOnly === true ? undefined : elicitation;
+  const projectOutcome = createCreationOutcomeText<
+    z.infer<typeof createProjectOutputSchema>
+  >('create_project', (project) => project.ref);
+  const createProjectPolicy = costConfirmation?.costConfirmation.policy<
+    z.infer<typeof createProjectInputSchema>
+  >({
+    tool: 'create_project',
+    canonicalArguments: ({ name, region, organization_id }) => ({
+      name,
+      region,
+      organization_id,
+    }),
+    subject: ({ name, organization_id }) => ({
+      resourceName: name,
+      account: { type: 'organization', id: organization_id },
+    }),
+    readRate: ({ organization_id }) =>
+      costConfirmation.readProjectCreationRate(organization_id),
+  });
   return {
     list_organizations: tool({
       ...accountToolDefs.list_organizations,
@@ -256,30 +290,45 @@ export function getAccountTools({ account, readOnly }: AccountToolsOptions) {
     }),
     confirm_cost: tool({
       ...accountToolDefs.confirm_cost,
+      hidden: (ctx) => costConfirmation?.costConfirmation.capable(ctx) === true,
+      policy: costConfirmation?.costConfirmation.legacyConfirmationPolicy,
       execute: async (cost) => {
         return { confirmation_id: await hashObject(cost) };
       },
     }),
-    create_project: tool({
+    create_project: tool<
+      typeof createProjectInputSchema,
+      typeof createProjectOutputSchema,
+      CostConfirmationResolution | undefined
+    >({
       ...accountToolDefs.create_project,
-      execute: async ({ name, region, organization_id, confirm_cost_id }) => {
+      policy: createProjectPolicy,
+      formatResult: (project) => projectOutcome.render(project, project.name),
+      execute: async (
+        { name, region, organization_id, confirm_cost_id },
+        resolution
+      ) => {
         if (readOnly) {
           throw new Error('Cannot create a project in read-only mode.');
         }
 
-        const cost = await getNextProjectCost(account, organization_id);
-        const costHash = await hashObject(cost);
-        if (costHash !== confirm_cost_id) {
-          throw new Error(
-            'Cost confirmation ID does not match the expected cost of creating a project.'
-          );
+        if (resolution === undefined) {
+          const cost = await getNextProjectCost(account, organization_id);
+          const costHash = await hashObject(cost);
+          if (costHash !== confirm_cost_id) {
+            throw new Error(
+              'Cost confirmation ID does not match the expected cost of creating a project.'
+            );
+          }
         }
 
-        return await account.createProject({
+        const project = await account.createProject({
           name,
           region,
           organization_id,
         });
+        projectOutcome.record(project, resolution);
+        return project;
       },
     }),
     pause_project: tool({

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -1,5 +1,11 @@
 import { tool } from '@supabase/mcp-utils';
 import { z } from 'zod/v4';
+import {
+  type CostConfirmation,
+  type CostConfirmationResolution,
+  createCreationOutcomeText,
+  type CreationRate,
+} from '../cost-confirmation.js';
 import type { BranchingOperations } from '../platform/types.js';
 import { branchSchema } from '../platform/types.js';
 import { getBranchCost } from '../pricing.js';
@@ -10,6 +16,10 @@ type BranchingToolsOptions = {
   branching: BranchingOperations;
   projectId?: string;
   readOnly?: boolean;
+  elicitation?: {
+    costConfirmation: CostConfirmation;
+    readBranchCreationRate(projectId: string): Promise<CreationRate>;
+  };
 };
 
 const createBranchInputSchema = z.object({
@@ -155,26 +165,54 @@ export function getBranchingTools({
   branching,
   projectId,
   readOnly,
+  elicitation,
 }: BranchingToolsOptions) {
   const project_id = projectId;
-
+  const costConfirmation = readOnly === true ? undefined : elicitation;
+  const branchOutcome = createCreationOutcomeText<
+    z.infer<typeof createBranchOutputSchema>
+  >('create_branch', (branch) => branch.id);
+  const createBranchPolicy = costConfirmation?.costConfirmation.policy<
+    z.infer<typeof createBranchInputSchema>
+  >({
+    tool: 'create_branch',
+    canonicalArguments: ({ project_id, name }) => ({ project_id, name }),
+    subject: ({ project_id, name }) => ({
+      resourceName: name,
+      account: { type: 'parent_project', id: project_id },
+    }),
+    readRate: ({ project_id }) =>
+      costConfirmation.readBranchCreationRate(project_id),
+  });
   return {
-    create_branch: injectableTool({
+    create_branch: injectableTool<
+      typeof createBranchInputSchema,
+      typeof createBranchOutputSchema,
+      { project_id: string | undefined },
+      CostConfirmationResolution | undefined
+    >({
       ...branchingToolDefs.create_branch,
+      policy: createBranchPolicy,
+      formatResult: (branch) => branchOutcome.render(branch, branch.name),
       inject: { project_id },
-      execute: async ({ project_id, name, confirm_cost_id }) => {
+      execute: async ({ project_id, name, confirm_cost_id }, resolution) => {
         if (readOnly) {
           throw new Error('Cannot create a branch in read-only mode.');
         }
 
-        const cost = getBranchCost();
-        const costHash = await hashObject(cost);
-        if (costHash !== confirm_cost_id) {
-          throw new Error(
-            'Cost confirmation ID does not match the expected cost of creating a branch.'
-          );
+        if (resolution === undefined) {
+          const cost = getBranchCost();
+          const costHash = await hashObject(cost);
+          if (costHash !== confirm_cost_id) {
+            throw new Error(
+              'Cost confirmation ID does not match the expected cost of creating a branch.'
+            );
+          }
         }
-        return await branching.createBranch(project_id, { name });
+
+        const branch = await branching.createBranch(project_id, { name });
+        branchOutcome.record(branch, resolution);
+        return branch;
       },
     }),
     list_branches: injectableTool({

--- a/packages/mcp-server-supabase/src/tools/util.ts
+++ b/packages/mcp-server-supabase/src/tools/util.ts
@@ -10,7 +10,7 @@ export type ToolDef = {
   /** 'adapt' = stays available in read-only mode, adapts behavior. 'exclude' (default) = removed from tool list. */
   readOnlyBehavior?: 'exclude' | 'adapt';
   /** If true, excludes the tool from `tools/list` while keeping it callable via `tools/call`. */
-  hidden?: boolean;
+  hidden?: Tool['hidden'];
 };
 
 export type ToolDefs = Record<string, ToolDef>;
@@ -23,7 +23,8 @@ export type InjectableTool<
   Params extends z.ZodObject,
   OutputSchema extends z.ZodObject,
   Injected extends Partial<z.infer<Params>> = {},
-> = Tool<Params, OutputSchema> & {
+  Resolution = never,
+> = Tool<Params, OutputSchema, Resolution> & {
   /**
    * Optionally injects static parameter values into the tool's
    * execute function and removes them from the parameter schema.
@@ -38,15 +39,18 @@ export function injectableTool<
   Params extends z.ZodObject,
   OutputSchema extends z.ZodObject,
   Injected extends Partial<z.infer<Params>>,
+  Resolution = never,
 >({
   description,
   annotations,
   parameters,
   outputSchema,
   hidden,
+  policy,
   inject,
   execute,
-}: InjectableTool<Params, OutputSchema, Injected>) {
+  formatResult,
+}: InjectableTool<Params, OutputSchema, Injected, Resolution>) {
   // If all injected parameters are undefined, return the original tool
   if (!inject || Object.values(inject).every((value) => value === undefined)) {
     return tool({
@@ -55,7 +59,9 @@ export function injectableTool<
       parameters,
       outputSchema,
       hidden,
+      policy,
       execute,
+      formatResult,
     });
   }
 
@@ -71,9 +77,10 @@ export function injectableTool<
 
   // Wrapper that merges injected values with provided args
   const executeWithInjection = async (
-    args: z.infer<typeof cleanParametersSchema>
+    args: z.infer<typeof cleanParametersSchema>,
+    ...resolution: [Resolution] extends [never] ? [] : [Resolution]
   ) => {
-    return execute({ ...args, ...inject } as z.infer<Params>);
+    return execute({ ...args, ...inject } as z.infer<Params>, ...resolution);
   };
 
   return tool({
@@ -82,7 +89,13 @@ export function injectableTool<
     parameters: cleanParametersSchema,
     outputSchema,
     hidden,
+    policy: policy && {
+      ...policy,
+      resolve: (args, ctx) =>
+        policy.resolve({ ...args, ...inject } as z.infer<Params>, ctx),
+    },
     execute: executeWithInjection,
+    formatResult,
   });
 }
 

--- a/packages/mcp-server-supabase/src/util.ts
+++ b/packages/mcp-server-supabase/src/util.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { canonicalObjectDigest } from './object-digest.js';
 import type { SupabasePlatform } from './platform/types.js';
 import { PLATFORM_INDEPENDENT_FEATURES } from './server.js';
 import {
@@ -35,27 +36,7 @@ export async function hashObject(
   obj: Record<string, any>,
   length?: number
 ): Promise<string> {
-  // Sort object keys to ensure consistent output regardless of original key order
-  const str = JSON.stringify(obj, (_, value) => {
-    if (value && typeof value === 'object' && !Array.isArray(value)) {
-      return Object.keys(value)
-        .sort()
-        .reduce<Record<string, any>>((result, key) => {
-          result[key] = value[key];
-          return result;
-        }, {});
-    }
-    return value;
-  });
-
-  const buffer = await crypto.subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(str)
-  );
-
-  // Convert to base64
-  const base64Hash = btoa(String.fromCharCode(...new Uint8Array(buffer)));
-  return base64Hash.slice(0, length);
+  return canonicalObjectDigest(obj, length);
 }
 
 /**

--- a/packages/mcp-server-supabase/test/cost-platform.ts
+++ b/packages/mcp-server-supabase/test/cost-platform.ts
@@ -35,6 +35,7 @@ export const FIXED_BRANCH = {
   parent_project_ref: 'fixed-project-ref',
   is_default: false,
   persistent: false,
+  with_data: false,
   status: 'CREATING_PROJECT' as const,
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z',

--- a/packages/mcp-server-supabase/test/cost-platform.ts
+++ b/packages/mcp-server-supabase/test/cost-platform.ts
@@ -1,0 +1,106 @@
+import type { CreationRate } from '../src/cost-confirmation.js';
+import type {
+  AccountOperations,
+  BranchingOperations,
+  SupabasePlatform,
+} from '../src/platform/types.js';
+
+export const PROJECT_RATE: CreationRate = {
+  amount: 10,
+  currency: 'USD',
+  recurrence: 'monthly',
+};
+
+export const BRANCH_RATE: CreationRate = {
+  amount: 0.01344,
+  currency: 'USD',
+  recurrence: 'hourly',
+};
+
+export const FIXED_PROJECT = {
+  id: 'fixed-project-ref',
+  ref: 'fixed-project-ref',
+  organization_id: 'fixed-org',
+  organization_slug: 'fixed-org',
+  name: 'Fixture Project',
+  status: 'UNKNOWN',
+  created_at: '2026-01-01T00:00:00.000Z',
+  region: 'us-east-1',
+};
+
+export const FIXED_BRANCH = {
+  id: 'fixed-branch',
+  name: 'develop',
+  project_ref: 'fixed-branch-ref',
+  parent_project_ref: 'fixed-project-ref',
+  is_default: false,
+  persistent: false,
+  status: 'CREATING_PROJECT' as const,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+export function createCostPlatform() {
+  const calls: string[] = [];
+  const projectRates: CreationRate[] = [];
+  const branchRates: CreationRate[] = [];
+
+  const account: AccountOperations = {
+    async listOrganizations() {
+      return [{ id: 'fixed-org', slug: 'fixed-org', name: 'Fixture Org' }];
+    },
+    async getOrganization() {
+      return {
+        id: 'fixed-org',
+        name: 'Fixture Org',
+        plan: 'pro',
+        allowed_release_channels: ['ga'],
+        opt_in_tags: [],
+      };
+    },
+    async listProjects() {
+      return [FIXED_PROJECT];
+    },
+    async getProject() {
+      return FIXED_PROJECT;
+    },
+    async createProject() {
+      calls.push('create_project');
+      return FIXED_PROJECT;
+    },
+    async pauseProject() {},
+    async restoreProject() {},
+  };
+
+  const branching: BranchingOperations = {
+    async listBranches() {
+      return [];
+    },
+    async createBranch() {
+      calls.push('create_branch');
+      return FIXED_BRANCH;
+    },
+    async deleteBranch() {},
+    async mergeBranch() {},
+    async resetBranch() {},
+    async rebaseBranch() {},
+  };
+
+  const readProjectCreationRate = async () => {
+    calls.push('read_project_rate');
+    return projectRates.shift() ?? PROJECT_RATE;
+  };
+  const readBranchCreationRate = async () => {
+    calls.push('read_branch_rate');
+    return branchRates.shift() ?? BRANCH_RATE;
+  };
+
+  return {
+    platform: { account, branching } satisfies SupabasePlatform,
+    calls,
+    projectRates,
+    branchRates,
+    readProjectCreationRate,
+    readBranchCreationRate,
+  };
+}


### PR DESCRIPTION
## Why

This replacement keeps the hosted cost-confirmation path small and on the public contracts we already approved: the official SDK’s `inputRequired` flow + mcp-utils `ToolPolicy`.

It’s a draft stacked on `barryroodt/ai-1091-tool-policy-foundation` at `9ecf0bd`. It supersedes #378 and #379 as the path under review, while both stay open as paused drafts until slice 1 and hosted acceptance prove this approach. I’ll decide when to close them.

## What changed

- Added a package-private transport adapter for the SDK elicitation form and `elicitUrl` shapes, including the default and classic `confirm_cost` legacy shim paths.
- Added the cost policy for initial/final rate reads, sealed request state, expiry, response handling, telemetry, zero-rate calls, stale terminal requests, and legacy lanes.
- Added an optional neste d hosted `elicitation` block to `createSupabaseMcpServer`. When supplied, its dependencies are required and fail closed.
- Kept the existing public entry points unchanged: no new entry point or runtime export, no SupabasePlatform rate methods, no v2 spec/type/API reader changes, and no mcp-utils diff.
- Left the obsolete custom runtime, state, codec, recovery, capability, gate, and interaction modules behind rather than porting them.

A regression against the real SDK showed that the widened modern output schema stripped `BranchResponse.with_data`. The schema is now `.loose()`, preserving real API fields while accepted business output and the exact declined/cancelled `structuredContent` remain valid.

Per my 2026-08-28 decision, the kill switch falls back to the existing `confirm_cost` flow here. Hard-block behavior is deferred to the planned follow-up work.

Legacy project discovery, branch discovery, cost confirmation, and creation output still match the baseline. Stdio remains on its existing hardcoded l egacy path.

## Verification

Charter gates are green at `9f7eef207043ea3dffc81f99fcbb631b71516c35`:

- Build: 3 packages
- mcp-utils: 3 files, 53 tests
- Supabase unit + integration: 17 files, 264 tests
- Packed consumer: 3 assertions
- Focused modern output-schema check: 1
- Legacy project + branch byte checks: 1
- Format: 97 files

## Before merge

- Review the security delta from the custom codec to the SDK codec, especially the floor-second expiry boundary.
- Do an error-path UX pass.

Hosted cross-instance acceptance stays with the platform PR. The external plan now matches that sequence.