### PR TITLE
feat: group lints in `get_advisors` response

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -2340,6 +2340,119 @@ describe('tools', () => {
     expect(result).toEqual({ lints: [] });
   });
 
+  test('get advisors groups repeated lints for both security and performance', async () => {
+    const platform: SupabasePlatform = {
+      debugging: {
+        getLogs() {
+          throw new Error('Not implemented');
+        },
+        async getSecurityAdvisors() {
+          return {
+            lints: [
+              {
+                name: 'function_search_path_mutable',
+                title: 'Function Search Path Mutable',
+                level: 'WARN',
+                facing: 'EXTERNAL',
+                categories: ['SECURITY'],
+                description:
+                  'Detects functions where the search_path parameter is not set.',
+                detail: 'Function `public.a` has a role mutable search_path',
+                remediation:
+                  'https://supabase.com/docs/guides/database/database-linter',
+                cache_key: 'function_search_path_mutable_public_a',
+              },
+              {
+                name: 'function_search_path_mutable',
+                title: 'Function Search Path Mutable',
+                level: 'WARN',
+                facing: 'EXTERNAL',
+                categories: ['SECURITY'],
+                description:
+                  'Detects functions where the search_path parameter is not set.',
+                detail: 'Function `public.b` has a role mutable search_path',
+                remediation:
+                  'https://supabase.com/docs/guides/database/database-linter',
+                cache_key: 'function_search_path_mutable_public_b',
+              },
+            ],
+          };
+        },
+        async getPerformanceAdvisors() {
+          return {
+            lints: [
+              { name: 'unused_index', level: 'INFO', detail: 'index a' },
+              { name: 'unused_index', level: 'INFO', detail: 'index b' },
+            ],
+          };
+        },
+      },
+    };
+
+    const { callTool } = await setup({ platform, features: ['debugging'] });
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const { result: security } = await callTool({
+      name: 'get_advisors',
+      arguments: {
+        project_id: project.id,
+        type: 'security',
+      },
+    });
+
+    expect(security).toEqual({
+      lints: [
+        {
+          name: 'function_search_path_mutable',
+          title: 'Function Search Path Mutable',
+          level: 'WARN',
+          facing: 'EXTERNAL',
+          categories: ['SECURITY'],
+          description:
+            'Detects functions where the search_path parameter is not set.',
+          remediation:
+            'https://supabase.com/docs/guides/database/database-linter',
+          count: 2,
+          findings: [
+            { detail: 'Function `public.a` has a role mutable search_path' },
+            { detail: 'Function `public.b` has a role mutable search_path' },
+          ],
+        },
+      ],
+    });
+
+    const { result: performance } = await callTool({
+      name: 'get_advisors',
+      arguments: {
+        project_id: project.id,
+        type: 'performance',
+      },
+    });
+
+    expect(performance).toEqual({
+      lints: [
+        {
+          name: 'unused_index',
+          level: 'INFO',
+          count: 2,
+          findings: [{ detail: 'index a' }, { detail: 'index b' }],
+        },
+      ],
+    });
+  });
+
   test('get performance advisors', async () => {
     const { callTool } = await setup();
 

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.test.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, test } from 'vitest';
-import { DAY_MS, resolveLogWindow } from './debugging-tools.js';
+import type { components } from '../management-api/types.js';
+import {
+  DAY_MS,
+  groupAdvisorLints,
+  groupAdvisorsResult,
+  resolveLogWindow,
+} from './debugging-tools.js';
+
+/**
+ * The lint shape the Management API actually returns, so these fixtures fail
+ * typecheck if `GET /v1/projects/{ref}/advisors/{type}` changes under us.
+ */
+type AdvisorLint =
+  components['schemas']['V1ProjectAdvisorsResponse']['lints'][number];
 
 describe('resolveLogWindow', () => {
   test('defaults the end to now and the start to 24 hours before it', () => {
@@ -67,5 +80,157 @@ describe('resolveLogWindow', () => {
     const end = '2024-02-02T00:00:00.000Z';
 
     expect(() => resolveLogWindow(start, end)).not.toThrow();
+  });
+});
+
+describe('groupAdvisorLints', () => {
+  function lint(overrides: Record<string, unknown> = {}): AdvisorLint {
+    return {
+      name: 'function_search_path_mutable',
+      title: 'Function Search Path Mutable',
+      level: 'WARN',
+      facing: 'EXTERNAL',
+      categories: ['SECURITY'],
+      description:
+        'Detects functions where the search_path parameter is not set.',
+      detail: 'Function `public.a` has a role mutable search_path',
+      remediation: 'https://supabase.com/docs/guides/database/database-linter',
+      metadata: { schema: 'public', name: 'a', type: 'function' },
+      cache_key: 'function_search_path_mutable_public_a',
+      ...overrides,
+    };
+  }
+
+  test('collapses repeated lints into one entry', () => {
+    const grouped = groupAdvisorLints([
+      lint(),
+      lint({
+        detail: 'Function `public.b` has a role mutable search_path',
+        metadata: { schema: 'public', name: 'b', type: 'function' },
+        cache_key: 'function_search_path_mutable_public_b',
+      }),
+    ]);
+
+    expect(grouped).toEqual([
+      {
+        name: 'function_search_path_mutable',
+        title: 'Function Search Path Mutable',
+        level: 'WARN',
+        facing: 'EXTERNAL',
+        categories: ['SECURITY'],
+        description:
+          'Detects functions where the search_path parameter is not set.',
+        remediation:
+          'https://supabase.com/docs/guides/database/database-linter',
+        count: 2,
+        findings: [
+          {
+            detail: 'Function `public.a` has a role mutable search_path',
+            metadata: { schema: 'public', name: 'a', type: 'function' },
+          },
+          {
+            detail: 'Function `public.b` has a role mutable search_path',
+            metadata: { schema: 'public', name: 'b', type: 'function' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('keeps unknown fields on the finding', () => {
+    const [group] = groupAdvisorLints([
+      lint({ observed_at: '2026-08-22T11:20:43.184Z', future_field: 42 }),
+    ]);
+
+    expect(group?.findings[0]).toMatchObject({
+      detail: 'Function `public.a` has a role mutable search_path',
+      observed_at: '2026-08-22T11:20:43.184Z',
+      future_field: 42,
+    });
+  });
+
+  test('drops cache_key', () => {
+    const [group] = groupAdvisorLints([lint()]);
+
+    expect(group?.findings[0]).not.toHaveProperty('cache_key');
+    expect(group).not.toHaveProperty('cache_key');
+  });
+
+  test('splits lints sharing a name but differing on a shared field', () => {
+    const grouped = groupAdvisorLints([
+      lint({ name: 'rls_enabled_no_policy', level: 'INFO' }),
+      lint({ name: 'rls_enabled_no_policy', level: 'WARN' }),
+    ]);
+
+    expect(grouped).toHaveLength(2);
+    expect(grouped.map((group) => group.level)).toEqual(['INFO', 'WARN']);
+  });
+
+  test('preserves first-seen order', () => {
+    const grouped = groupAdvisorLints([
+      lint({ name: 'unused_index' }),
+      lint(),
+      lint({ name: 'unused_index' }),
+    ]);
+
+    expect(grouped.map((group) => [group.name, group.count])).toEqual([
+      ['unused_index', 2],
+      ['function_search_path_mutable', 1],
+    ]);
+  });
+
+  test('handles an empty list', () => {
+    expect(groupAdvisorLints([])).toEqual([]);
+  });
+});
+
+describe('groupAdvisorsResult', () => {
+  test('groups lints and preserves sibling fields', () => {
+    const result = groupAdvisorsResult({
+      lints: [
+        {
+          name: 'unused_index',
+          title: 'Unused Index',
+          level: 'INFO',
+          detail: 'Index `idx_a` has not been used',
+        },
+        {
+          name: 'unused_index',
+          title: 'Unused Index',
+          level: 'INFO',
+          detail: 'Index `idx_b` has not been used',
+        },
+      ],
+      other_field: 'untouched',
+    });
+
+    expect(result).toEqual({
+      lints: [
+        {
+          name: 'unused_index',
+          title: 'Unused Index',
+          level: 'INFO',
+          count: 2,
+          findings: [
+            { detail: 'Index `idx_a` has not been used' },
+            { detail: 'Index `idx_b` has not been used' },
+          ],
+        },
+      ],
+      other_field: 'untouched',
+    });
+  });
+
+  test('passes through an unrecognised payload', () => {
+    for (const result of [
+      undefined,
+      null,
+      'nope',
+      {},
+      { lints: 'nope' },
+      { lints: [1, 2] },
+    ]) {
+      expect(groupAdvisorsResult(result)).toEqual(result);
+    }
   });
 });

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.test.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.test.ts
@@ -7,10 +7,6 @@ import {
   resolveLogWindow,
 } from './debugging-tools.js';
 
-/**
- * The lint shape the Management API actually returns, so these fixtures fail
- * typecheck if `GET /v1/projects/{ref}/advisors/{type}` changes under us.
- */
 type AdvisorLint =
   components['schemas']['V1ProjectAdvisorsResponse']['lints'][number];
 

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.test.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.test.ts
@@ -178,6 +178,15 @@ describe('groupAdvisorLints', () => {
   test('handles an empty list', () => {
     expect(groupAdvisorLints([])).toEqual([]);
   });
+
+  test('keeps a lint with an explicit null shared field separate from one missing the field', () => {
+    const explicitNull = lint({ remediation: null });
+    const { remediation, ...missingRemediation } = lint();
+
+    const grouped = groupAdvisorLints([explicitNull, missingRemediation]);
+
+    expect(grouped).toHaveLength(2);
+  });
 });
 
 describe('groupAdvisorsResult', () => {

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -162,10 +162,8 @@ function isAdvisorLintArray(value: unknown): value is AdvisorLint[] {
 
 /**
  * Collapses a flat lint list into one entry per distinct lint, with the
- * per-object details listed underneath.
- *
- * Keyed on every shared field rather than `name` alone, so findings only merge
- * when all of them match.
+ * per-object findings underneath. Keyed on every shared field, so findings only
+ * merge when all of them match.
  */
 export function groupAdvisorLints(lints: AdvisorLint[]): GroupedAdvisorLint[] {
   const groups = new Map<string, GroupedAdvisorLint>();
@@ -203,8 +201,8 @@ export function groupAdvisorLints(lints: AdvisorLint[]): GroupedAdvisorLint[] {
 
 /**
  * Groups the lints in an advisors response and leaves the rest of the payload
- * alone. An unrecognised shape passes through untouched, so an API change
- * degrades to the ungrouped response instead of throwing.
+ * alone. An unrecognised shape passes through, so an API change degrades to the
+ * ungrouped response instead of throwing.
  */
 export function groupAdvisorsResult(result: unknown): unknown {
   if (typeof result !== 'object' || result === null || !('lints' in result)) {

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -128,6 +128,97 @@ const getAdvisorsOutputSchema = z.object({
   result: z.unknown(),
 });
 
+/** Fields the API repeats verbatim on every finding of the same lint. */
+const SHARED_LINT_FIELDS = [
+  'name',
+  'title',
+  'level',
+  'facing',
+  'categories',
+  'description',
+  'remediation',
+] as const;
+
+/**
+ * `cache_key` is mainly used for Studio's advisor UI, for selecting individual
+ * lints via the `id` query param. Not meaningful for MCP clients.
+ * https://github.com/supabase/supabase/blob/d5ee11bea0cba0149d16715aabb088d03c10be36/apps/studio/pages/project/%5Bref%5D/advisors/security.tsx#L64
+ */
+const DROPPED_LINT_FIELDS: readonly string[] = ['cache_key'];
+
+type AdvisorLint = Record<string, unknown>;
+
+type GroupedAdvisorLint = {
+  count: number;
+  findings: AdvisorLint[];
+} & AdvisorLint;
+
+function isAdvisorLintArray(value: unknown): value is AdvisorLint[] {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => typeof item === 'object' && item !== null)
+  );
+}
+
+/**
+ * Collapses a flat lint list into one entry per distinct lint, with the
+ * per-object details listed underneath.
+ *
+ * Keyed on every shared field rather than `name` alone, so findings only merge
+ * when all of them match.
+ */
+export function groupAdvisorLints(lints: AdvisorLint[]): GroupedAdvisorLint[] {
+  const groups = new Map<string, GroupedAdvisorLint>();
+
+  for (const lint of lints) {
+    const shared: AdvisorLint = {};
+    const finding: AdvisorLint = {};
+
+    for (const [key, value] of Object.entries(lint)) {
+      if (DROPPED_LINT_FIELDS.includes(key)) {
+        continue;
+      }
+      if ((SHARED_LINT_FIELDS as readonly string[]).includes(key)) {
+        shared[key] = value;
+      } else {
+        finding[key] = value;
+      }
+    }
+
+    const key = JSON.stringify(
+      SHARED_LINT_FIELDS.map((field) => shared[field] ?? null)
+    );
+
+    const group = groups.get(key);
+    if (group) {
+      group.count += 1;
+      group.findings.push(finding);
+    } else {
+      groups.set(key, { ...shared, count: 1, findings: [finding] });
+    }
+  }
+
+  return Array.from(groups.values());
+}
+
+/**
+ * Groups the lints in an advisors response and leaves the rest of the payload
+ * alone. An unrecognised shape passes through untouched, so an API change
+ * degrades to the ungrouped response instead of throwing.
+ */
+export function groupAdvisorsResult(result: unknown): unknown {
+  if (typeof result !== 'object' || result === null || !('lints' in result)) {
+    return result;
+  }
+
+  const { lints } = result as { lints: unknown };
+  if (!isAdvisorLintArray(lints)) {
+    return result;
+  }
+
+  return { ...result, lints: groupAdvisorLints(lints) };
+}
+
 export const debuggingToolDefs = {
   get_logs: {
     description:
@@ -270,7 +361,7 @@ export function getDebuggingTools({
           default:
             throw new Error(`Unknown advisor type: ${type}`);
         }
-        return { result };
+        return { result: groupAdvisorsResult(result) };
       },
     }),
   };

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -183,9 +183,7 @@ export function groupAdvisorLints(lints: AdvisorLint[]): GroupedAdvisorLint[] {
       }
     }
 
-    const key = JSON.stringify(
-      SHARED_LINT_FIELDS.map((field) => shared[field] ?? null)
-    );
+    const key = JSON.stringify(shared);
 
     const group = groups.get(key);
     if (group) {

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -129,7 +129,7 @@ const getAdvisorsOutputSchema = z.object({
 });
 
 /** Fields the API repeats verbatim on every finding of the same lint. */
-const SHARED_LINT_FIELDS = [
+const SHARED_LINT_FIELDS: readonly string[] = [
   'name',
   'title',
   'level',
@@ -137,7 +137,7 @@ const SHARED_LINT_FIELDS = [
   'categories',
   'description',
   'remediation',
-] as const;
+];
 
 /**
  * `cache_key` is mainly used for Studio's advisor UI, for selecting individual
@@ -178,7 +178,7 @@ export function groupAdvisorLints(lints: AdvisorLint[]): GroupedAdvisorLint[] {
       if (DROPPED_LINT_FIELDS.includes(key)) {
         continue;
       }
-      if ((SHARED_LINT_FIELDS as readonly string[]).includes(key)) {
+      if (SHARED_LINT_FIELDS.includes(key)) {
         shared[key] = value;
       } else {
         finding[key] = value;


### PR DESCRIPTION
## Problem

`get_advisors` returns a list with one object per finding, each carrying the same keys.  The [lint SQL](https://github.com/supabase/supabase/blob/d5ee11bea0cba0149d16715aabb088d03c10be36/packages/pg-meta/src/sql/studio/advisor/lints.ts) emits `title`, `description` and `remediation` as literals on each row, so 300 instances of the same lint means those same three strings 300 times.

See diagnosis [thread](https://supabase.slack.com/archives/C051L8U2EJF/p1787774307978489) with [metrics](https://supabase.slack.com/archives/C051L8U2EJF/p1787777939555179?thread_ts=1787774307.978489&cid=C051L8U2EJF) demonstrating that is is the longest tail context hog in studio's AI Assistant.

## Fix

Groups findings by lint.

- Findings only merge when all seven [shared fields](https://github.com/supabase/mcp/pull/390/changes#diff-38cc0dc8b54f71f78652c17cbd5d29002718be0c4f3b0493e36f448f428e2b3eR132-R140) match
- Merged findings appear as a `findings` list on the `lints` entry, with convenience `count`
- Drops `cache_key`, which primarily exists for [the dashboard UI](https://github.com/supabase/supabase/blob/d5ee11bea0cba0149d16715aabb088d03c10be36/apps/studio/pages/project/%5Bref%5D/advisors/security.tsx#L64)

**Before**

```jsonc
{ "lints": [
  { "name": "lint_a", "title": "…", "level": "WARN", "facing": "…", "categories": ["…"], "description": "…", "remediation": "…",
    "detail": "… object_1 …", "metadata": { "name": "object_1" }, "cache_key": "…" },
  { "name": "lint_a", "title": "…", "level": "WARN", "facing": "…", "categories": ["…"], "description": "…", "remediation": "…",
    "detail": "… object_2 …", "metadata": { "name": "object_2" }, "cache_key": "…" },
  { "name": "lint_a", "title": "…", "level": "WARN", "facing": "…", "categories": ["…"], "description": "…", "remediation": "…",
    "detail": "… object_3 …", "metadata": { "name": "object_3" }, "cache_key": "…" },
  { "name": "lint_a", "title": "…", "level": "WARN", "facing": "…", "categories": ["…"], "description": "…", "remediation": "…",
    "detail": "… object_4 …", "metadata": { "name": "object_4" }, "cache_key": "…" },
  { "name": "lint_a", "title": "…", "level": "WARN", "facing": "…", "categories": ["…"], "description": "…", "remediation": "…",
    "detail": "… object_5 …", "metadata": { "name": "object_5" }, "cache_key": "…" },
  // ...296 more, each repeating the same 7 shared fields
]}
```

**After**

```jsonc
{ "lints": [
  { "name": "lint_a", "title": "…", "level": "WARN", "facing": "…", "categories": ["…"], "description": "…", "remediation": "…",
    "count": 301,
    "findings": [
      { "detail": "… object_1 …", "metadata": { "name": "object_1" } },
      { "detail": "… object_2 …", "metadata": { "name": "object_2" } },
      { "detail": "… object_3 …", "metadata": { "name": "object_3" } },
      { "detail": "… object_4 …", "metadata": { "name": "object_4" } },
      { "detail": "… object_5 …", "metadata": { "name": "object_5" } },
      // ...296 more
    ] }
]}
```

In the turn cited above, the response shrinks to 293,485 chars, ~73k tokens.


## How to review

Take a look at the new [tests](https://github.com/supabase/mcp/pull/390/changes#diff-4111b138e3c190a9303040787d584d08b2aa6b92a097b36bd47fa299c3008442) to understand the expecting grouping behavior.

Point an MCP client at the [preview](https://github.com/supabase/mcp/pull/390#issuecomment-5455072142) build below then call `get_advisors` for a project with some advisors, and observe the shape.

Screenshot from my testing in MCP Inspector:

<img width="3596" height="2056" alt="CleanShot 2026-08-28 at 12 42 40@2x" src="https://github.com/user-attachments/assets/f8008a9b-35f1-4be3-9fca-5dafd3eb3e6e" />

## Follow-ups

- Even with the shrunken response, tool outputs are unbounded and can flood context. The [worst recent call](https://www.braintrust.dev/app/supabase.io/p/Assistant/trace?object_type=project_logs&object_id=5a8d02e5-b3b6-40cc-ba76-ecee286478f4&r=e5531007-e026-45b5-8dad-5426260bb2dd&s=4e233645-2b9e-4abf-820a-c5fd785945c9) returned 10,649 findings, where even with grouping it's ~2.5x over Assistant's context limit. This exploration will continue in [AI-865](https://linear.app/supabase/issue/AI-865/spike-large-tool-output-handling-in-assistant).
- `detail` is only included per-finding because `pg-meta` puts index names, policy names, roles and actions in prose instead of `metadata`. If we fill those in, `detail` could be dropped entirely, making that same payload ~4x smaller


`tools/list` output is untouched so no ChatGPT resubmission needed.

Closes AI-1136






