### PR TITLE
feat(mcp): add project cost confirmation elicitation

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -59,7 +59,7 @@ type SetupOptions = {
   platform?: SupabasePlatform;
   readOnly?: boolean;
   features?: string[];
-  projectCostConfirmation?: SupabaseMcpServerOptions['projectCostConfirmation'];
+  costConfirmation?: SupabaseMcpServerOptions['costConfirmation'];
 };
 
 /**
@@ -71,7 +71,7 @@ async function setup(options: SetupOptions = {}) {
     projectId,
     readOnly,
     features,
-    projectCostConfirmation,
+    costConfirmation,
   } = options;
   const clientTransport = new StreamTransport();
   const serverTransport = new StreamTransport();
@@ -101,7 +101,7 @@ async function setup(options: SetupOptions = {}) {
     projectId,
     readOnly,
     features,
-    projectCostConfirmation,
+    costConfirmation,
   });
 
   await server.connect(serverTransport);
@@ -151,11 +151,12 @@ type FormCapableSetupOptions = {
   elicitationAction?: 'accept' | 'decline' | 'cancel';
 };
 
-const PROJECT_COST_CONFIRMATION: NonNullable<
-  SupabaseMcpServerOptions['projectCostConfirmation']
+const COST_CONFIRMATION: NonNullable<
+  SupabaseMcpServerOptions['costConfirmation']
 > = {
   requestStateKey: 'a'.repeat(32),
   principal: 'test-user',
+  enabledTools: ['create_project'],
 };
 
 // https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
@@ -190,7 +191,7 @@ async function setupFormCapable(options: FormCapableSetupOptions = {}) {
   const handler = createSupabaseMcpHandler({
     platform,
     readOnly,
-    projectCostConfirmation: PROJECT_COST_CONFIRMATION,
+    costConfirmation: COST_CONFIRMATION,
   });
 
   const transport = new StreamableHTTPClientTransport(MCP_ENDPOINT, {
@@ -615,7 +616,7 @@ describe('tools', () => {
 
     test('create_project advertises confirm_cost_id as optional when cost confirmation is configured', async () => {
       const { client } = await setup({
-        projectCostConfirmation: PROJECT_COST_CONFIRMATION,
+        costConfirmation: COST_CONFIRMATION,
       });
 
       const { tools } = await client.listTools();
@@ -630,7 +631,7 @@ describe('tools', () => {
 
     test('capability-free client still succeeds via get_cost -> confirm_cost -> create_project', async () => {
       const { callTool } = await setup({
-        projectCostConfirmation: PROJECT_COST_CONFIRMATION,
+        costConfirmation: COST_CONFIRMATION,
       });
 
       const freeOrg = await createOrganization({

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -864,6 +864,66 @@ describe('tools', () => {
       // reissued instead of creating.
       expect(mockProjects.size).toBe(1);
     });
+
+    test('a decline is honored even when the quoted cost changed since the state was minted', async () => {
+      const { client } = await setupFormCapable();
+
+      const org = await createOrganization({
+        name: 'Paid Org',
+        plan: 'pro',
+        allowed_release_channels: ['ga'],
+      });
+
+      const args = {
+        name: 'New Project',
+        region: 'us-east-1',
+        organization_id: org.id,
+      };
+
+      const first = (await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'create_project', arguments: args },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(first)) {
+        throw new Error('expected an input_required result');
+      }
+
+      // Pricing shifts between rounds: a new active project pushes this
+      // paid org past its free first-project allowance.
+      const priorProject = await createProject({
+        name: 'Existing Project',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      priorProject.status = 'ACTIVE_HEALTHY';
+
+      const second = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_project',
+            arguments: args,
+            inputResponses: {
+              confirm_cost: { action: 'decline' },
+            },
+            requestState: first.requestState,
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (isInputRequiredResult(second)) {
+        throw new Error('expected a CallToolResult');
+      }
+
+      expect(second.structuredContent).toEqual({ status: 'declined' });
+      // Only the project created directly above; declining never creates one.
+      expect(mockProjects.size).toBe(1);
+    });
   });
 
   test('pause project', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -1,5 +1,13 @@
-import { Client } from '@modelcontextprotocol/client';
-import type { CallToolRequestParams } from '@modelcontextprotocol/client';
+import {
+  Client,
+  isInputRequiredResult,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import type {
+  CallToolRequestParams,
+  CallToolResult,
+  InputRequiredResult,
+} from '@modelcontextprotocol/client';
 import { StreamTransport } from '@supabase/mcp-utils';
 import { codeBlock, stripIndent } from 'common-tags';
 import gqlmin from 'gqlmin';
@@ -18,16 +26,22 @@ import {
   MCP_CLIENT_NAME,
   MCP_CLIENT_VERSION,
   mockContentApiSchemaLoadCount,
+  mockProjects,
   setupMockApis,
 } from '../test/mocks.js';
 import { createSupabaseApiPlatform } from './platform/api-platform.js';
 import type { SupabasePlatform } from './platform/types.js';
 import { BRANCH_COST_HOURLY, PROJECT_COST_MONTHLY } from './pricing.js';
-import { createSupabaseMcpServer, instructions } from './server.js';
+import {
+  createSupabaseMcpServer,
+  instructions,
+  type SupabaseMcpServerOptions,
+} from './server.js';
 import {
   createToolSchemas,
   supabaseMcpToolSchemas,
 } from './tools/tool-schemas.js';
+import { createSupabaseMcpHandler } from './transports/http.js';
 
 let mockServer: SetupServer | undefined;
 
@@ -45,13 +59,20 @@ type SetupOptions = {
   platform?: SupabasePlatform;
   readOnly?: boolean;
   features?: string[];
+  projectCostConfirmation?: SupabaseMcpServerOptions['projectCostConfirmation'];
 };
 
 /**
  * Sets up an MCP client and server for testing.
  */
 async function setup(options: SetupOptions = {}) {
-  const { accessToken = ACCESS_TOKEN, projectId, readOnly, features } = options;
+  const {
+    accessToken = ACCESS_TOKEN,
+    projectId,
+    readOnly,
+    features,
+    projectCostConfirmation,
+  } = options;
   const clientTransport = new StreamTransport();
   const serverTransport = new StreamTransport();
 
@@ -80,6 +101,7 @@ async function setup(options: SetupOptions = {}) {
     projectId,
     readOnly,
     features,
+    projectCostConfirmation,
   });
 
   await server.connect(serverTransport);
@@ -117,6 +139,86 @@ async function setup(options: SetupOptions = {}) {
   }
 
   return { client, clientTransport, callTool, server, serverTransport };
+}
+
+type FormCapableSetupOptions = {
+  readOnly?: boolean;
+  /**
+   * Registers an auto-fulfilling `elicitation/create` handler that always
+   * answers with this action, driven via `client.callTool`. Omit for manual
+   * multi-round-trip control via `client.request`.
+   */
+  elicitationAction?: 'accept' | 'decline' | 'cancel';
+};
+
+const PROJECT_COST_CONFIRMATION: NonNullable<
+  SupabaseMcpServerOptions['projectCostConfirmation']
+> = {
+  requestStateKey: 'a'.repeat(32),
+  principal: 'test-user',
+};
+
+// https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
+const MODERN_PROTOCOL_VERSION = '2026-07-28';
+const MCP_ENDPOINT = new URL('https://mcp.test');
+
+/**
+ * Sets up an MCP client against the hosted HTTP handler (in-process, via a
+ * custom `fetch`) for the `create_project` cost-confirmation elicitation
+ * lane: a client pinned to the 2026-07-28 protocol, declaring per-request
+ * form capability. Raw `StreamTransport` only speaks the 2025 era, so the
+ * form-capable lane - which depends on the per-request `_meta` envelope -
+ * needs the same in-process HTTP transport the hosted runtime uses.
+ */
+async function setupFormCapable(options: FormCapableSetupOptions = {}) {
+  const { readOnly, elicitationAction } = options;
+
+  const platform = createSupabaseApiPlatform({
+    accessToken: ACCESS_TOKEN,
+    apiUrl: API_URL,
+  });
+
+  // Modern per-request serving never calls `onInitialize` (no `initialize`
+  // handshake on the 2026-07-28 wire), so the platform's management API
+  // client would otherwise keep its default User-Agent. Initialize it
+  // explicitly with the same clientInfo the test client below declares.
+  await platform.init?.({
+    clientInfo: { name: MCP_CLIENT_NAME, version: MCP_CLIENT_VERSION },
+    clientCapabilities: { elicitation: { form: {} } },
+  });
+
+  const handler = createSupabaseMcpHandler({
+    platform,
+    readOnly,
+    projectCostConfirmation: PROJECT_COST_CONFIRMATION,
+  });
+
+  const transport = new StreamableHTTPClientTransport(MCP_ENDPOINT, {
+    fetch: (url, init) => handler.fetch(new Request(url, init)),
+  });
+
+  const client = new Client(
+    { name: MCP_CLIENT_NAME, version: MCP_CLIENT_VERSION },
+    {
+      capabilities: { elicitation: { form: {} } },
+      versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } },
+      ...(elicitationAction === undefined && {
+        inputRequired: { autoFulfill: false },
+      }),
+    }
+  );
+
+  if (elicitationAction !== undefined) {
+    client.setRequestHandler('elicitation/create', async () =>
+      elicitationAction === 'accept'
+        ? { action: 'accept' as const, content: {} }
+        : { action: elicitationAction }
+    );
+  }
+
+  await client.connect(transport);
+
+  return { client };
 }
 
 describe('init', () => {
@@ -495,6 +597,272 @@ describe('tools', () => {
     await expect(createProjectPromise).rejects.toThrow(
       'User must confirm understanding of costs before creating a project.'
     );
+  });
+
+  describe('create_project cost confirmation via elicitation', () => {
+    test('create_project requires confirm_cost_id when cost confirmation is not configured', async () => {
+      const { client } = await setup();
+
+      const { tools } = await client.listTools();
+      const createProjectTool = tools.find(
+        (tool) => tool.name === 'create_project'
+      );
+
+      expect(createProjectTool?.inputSchema.required).toContain(
+        'confirm_cost_id'
+      );
+    });
+
+    test('create_project advertises confirm_cost_id as optional when cost confirmation is configured', async () => {
+      const { client } = await setup({
+        projectCostConfirmation: PROJECT_COST_CONFIRMATION,
+      });
+
+      const { tools } = await client.listTools();
+      const createProjectTool = tools.find(
+        (tool) => tool.name === 'create_project'
+      );
+
+      expect(createProjectTool?.inputSchema.required).not.toContain(
+        'confirm_cost_id'
+      );
+    });
+
+    test('capability-free client still succeeds via get_cost -> confirm_cost -> create_project', async () => {
+      const { callTool } = await setup({
+        projectCostConfirmation: PROJECT_COST_CONFIRMATION,
+      });
+
+      const freeOrg = await createOrganization({
+        name: 'Free Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const confirm_cost_id_result = await callTool({
+        name: 'confirm_cost',
+        arguments: { type: 'project', recurrence: 'monthly', amount: 0 },
+      });
+
+      const result = await callTool({
+        name: 'create_project',
+        arguments: {
+          name: 'New Project',
+          region: 'us-east-1',
+          organization_id: freeOrg.id,
+          confirm_cost_id: confirm_cost_id_result.confirmation_id,
+        },
+      });
+
+      expect(result).toMatchObject({
+        name: 'New Project',
+        region: 'us-east-1',
+        organization_id: freeOrg.id,
+      });
+      expect(mockProjects.size).toBe(1);
+    });
+
+    test('form-capable client: accept creates the project exactly once', async () => {
+      const { client } = await setupFormCapable({
+        elicitationAction: 'accept',
+      });
+
+      const freeOrg = await createOrganization({
+        name: 'Free Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const result = await client.callTool({
+        name: 'create_project',
+        arguments: {
+          name: 'New Project',
+          region: 'us-east-1',
+          organization_id: freeOrg.id,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const [content] = result.content;
+      if (content?.type !== 'text') {
+        throw new Error('expected text content');
+      }
+      const project = JSON.parse(content.text);
+      expect(project).toMatchObject({
+        name: 'New Project',
+        region: 'us-east-1',
+        organization_id: freeOrg.id,
+      });
+      expect(mockProjects.size).toBe(1);
+    });
+
+    test('form-capable client: decline does not create a project', async () => {
+      const { client } = await setupFormCapable({
+        elicitationAction: 'decline',
+      });
+
+      const freeOrg = await createOrganization({
+        name: 'Free Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const result = await client.callTool({
+        name: 'create_project',
+        arguments: {
+          name: 'New Project',
+          region: 'us-east-1',
+          organization_id: freeOrg.id,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toEqual({ status: 'declined' });
+      expect(mockProjects.size).toBe(0);
+    });
+
+    test('form-capable client: cancel does not create a project', async () => {
+      const { client } = await setupFormCapable({
+        elicitationAction: 'cancel',
+      });
+
+      const freeOrg = await createOrganization({
+        name: 'Free Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const result = await client.callTool({
+        name: 'create_project',
+        arguments: {
+          name: 'New Project',
+          region: 'us-east-1',
+          organization_id: freeOrg.id,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toEqual({ status: 'cancelled' });
+      expect(mockProjects.size).toBe(0);
+    });
+
+    test('rejects a retry whose arguments changed since the state was minted', async () => {
+      const { client } = await setupFormCapable();
+
+      const org = await createOrganization({
+        name: 'Free Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+      const otherOrg = await createOrganization({
+        name: 'Other Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const first = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_project',
+            arguments: {
+              name: 'New Project',
+              region: 'us-east-1',
+              organization_id: org.id,
+            },
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(first)) {
+        throw new Error('expected an input_required result');
+      }
+
+      const second = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_project',
+            arguments: {
+              name: 'New Project',
+              region: 'us-east-1',
+              organization_id: otherOrg.id,
+            },
+            inputResponses: {
+              confirm_cost: { action: 'accept', content: {} },
+            },
+            requestState: first.requestState,
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (isInputRequiredResult(second)) {
+        throw new Error('expected a CallToolResult');
+      }
+
+      expect(second.isError).toBe(true);
+      expect(second.structuredContent).toEqual({ status: 'error' });
+      expect(mockProjects.size).toBe(0);
+    });
+
+    test('reissues a fresh prompt when the quoted cost changes before confirmation', async () => {
+      const { client } = await setupFormCapable();
+
+      const org = await createOrganization({
+        name: 'Paid Org',
+        plan: 'pro',
+        allowed_release_channels: ['ga'],
+      });
+
+      const args = {
+        name: 'New Project',
+        region: 'us-east-1',
+        organization_id: org.id,
+      };
+
+      const first = (await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'create_project', arguments: args },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(first)) {
+        throw new Error('expected an input_required result');
+      }
+
+      // Pricing shifts between rounds: a new active project pushes this
+      // paid org past its free first-project allowance.
+      const priorProject = await createProject({
+        name: 'Existing Project',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      priorProject.status = 'ACTIVE_HEALTHY';
+
+      const second = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_project',
+            arguments: args,
+            inputResponses: {
+              confirm_cost: { action: 'accept', content: {} },
+            },
+            requestState: first.requestState,
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      expect(isInputRequiredResult(second)).toBe(true);
+      // Only the project created directly above; create_project itself
+      // reissued instead of creating.
+      expect(mockProjects.size).toBe(1);
+    });
   });
 
   test('pause project', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -601,6 +601,22 @@ describe('tools', () => {
   });
 
   describe('create_project cost confirmation via elicitation', () => {
+    async function createOrganizationWithBillableNextProject() {
+      const org = await createOrganization({
+        name: 'Paid Org',
+        plan: 'pro',
+        allowed_release_channels: ['ga'],
+      });
+      const existingProject = await createProject({
+        name: 'Existing Project',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      existingProject.status = 'ACTIVE_HEALTHY';
+
+      return { org, existingProject };
+    }
+
     test('create_project requires confirm_cost_id when cost confirmation is not configured', async () => {
       const { client } = await setup();
 
@@ -663,10 +679,8 @@ describe('tools', () => {
       expect(mockProjects.size).toBe(1);
     });
 
-    test('form-capable client: accept creates the project exactly once', async () => {
-      const { client } = await setupFormCapable({
-        elicitationAction: 'accept',
-      });
+    test('form-capable client: $0 creates without elicitation', async () => {
+      const { client } = await setupFormCapable();
 
       const freeOrg = await createOrganization({
         name: 'Free Org',
@@ -674,12 +688,41 @@ describe('tools', () => {
         allowed_release_channels: ['ga'],
       });
 
+      const result = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_project',
+            arguments: {
+              name: 'New Project',
+              region: 'us-east-1',
+              organization_id: freeOrg.id,
+            },
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      expect(isInputRequiredResult(result)).toBe(false);
+      if (isInputRequiredResult(result)) {
+        throw new Error('expected a CallToolResult');
+      }
+      expect(result.isError).toBeFalsy();
+      expect(mockProjects.size).toBe(1);
+    });
+
+    test('form-capable client: accept creates the project exactly once', async () => {
+      const { client } = await setupFormCapable({
+        elicitationAction: 'accept',
+      });
+      const { org } = await createOrganizationWithBillableNextProject();
+
       const result = await client.callTool({
         name: 'create_project',
         arguments: {
           name: 'New Project',
           region: 'us-east-1',
-          organization_id: freeOrg.id,
+          organization_id: org.id,
         },
       });
 
@@ -692,69 +735,54 @@ describe('tools', () => {
       expect(project).toMatchObject({
         name: 'New Project',
         region: 'us-east-1',
-        organization_id: freeOrg.id,
+        organization_id: org.id,
       });
-      expect(mockProjects.size).toBe(1);
+      expect(mockProjects.size).toBe(2);
     });
 
     test('form-capable client: decline does not create a project', async () => {
       const { client } = await setupFormCapable({
         elicitationAction: 'decline',
       });
-
-      const freeOrg = await createOrganization({
-        name: 'Free Org',
-        plan: 'free',
-        allowed_release_channels: ['ga'],
-      });
+      const { org } = await createOrganizationWithBillableNextProject();
 
       const result = await client.callTool({
         name: 'create_project',
         arguments: {
           name: 'New Project',
           region: 'us-east-1',
-          organization_id: freeOrg.id,
+          organization_id: org.id,
         },
       });
 
       expect(result.isError).toBeFalsy();
       expect(result.structuredContent).toEqual({ status: 'declined' });
-      expect(mockProjects.size).toBe(0);
+      expect(mockProjects.size).toBe(1);
     });
 
     test('form-capable client: cancel does not create a project', async () => {
       const { client } = await setupFormCapable({
         elicitationAction: 'cancel',
       });
-
-      const freeOrg = await createOrganization({
-        name: 'Free Org',
-        plan: 'free',
-        allowed_release_channels: ['ga'],
-      });
+      const { org } = await createOrganizationWithBillableNextProject();
 
       const result = await client.callTool({
         name: 'create_project',
         arguments: {
           name: 'New Project',
           region: 'us-east-1',
-          organization_id: freeOrg.id,
+          organization_id: org.id,
         },
       });
 
       expect(result.isError).toBeFalsy();
       expect(result.structuredContent).toEqual({ status: 'cancelled' });
-      expect(mockProjects.size).toBe(0);
+      expect(mockProjects.size).toBe(1);
     });
 
     test('rejects a retry whose arguments changed since the state was minted', async () => {
       const { client } = await setupFormCapable();
-
-      const org = await createOrganization({
-        name: 'Free Org',
-        plan: 'free',
-        allowed_release_channels: ['ga'],
-      });
+      const { org } = await createOrganizationWithBillableNextProject();
       const otherOrg = await createOrganization({
         name: 'Other Org',
         plan: 'free',
@@ -805,17 +833,13 @@ describe('tools', () => {
 
       expect(second.isError).toBe(true);
       expect(second.structuredContent).toEqual({ status: 'error' });
-      expect(mockProjects.size).toBe(0);
+      expect(mockProjects.size).toBe(1);
     });
 
-    test('reissues a fresh prompt when the quoted cost changes before confirmation', async () => {
+    test('creates without re-prompting when the quoted cost drops to zero before confirmation', async () => {
       const { client } = await setupFormCapable();
-
-      const org = await createOrganization({
-        name: 'Paid Org',
-        plan: 'pro',
-        allowed_release_channels: ['ga'],
-      });
+      const { org, existingProject } =
+        await createOrganizationWithBillableNextProject();
 
       const args = {
         name: 'New Project',
@@ -835,14 +859,7 @@ describe('tools', () => {
         throw new Error('expected an input_required result');
       }
 
-      // Pricing shifts between rounds: a new active project pushes this
-      // paid org past its free first-project allowance.
-      const priorProject = await createProject({
-        name: 'Existing Project',
-        region: 'us-east-1',
-        organization_id: org.id,
-      });
-      priorProject.status = 'ACTIVE_HEALTHY';
+      existingProject.status = 'INACTIVE';
 
       const second = (await client.request(
         {
@@ -859,20 +876,18 @@ describe('tools', () => {
         { allowInputRequired: true }
       )) as CallToolResult | InputRequiredResult;
 
-      expect(isInputRequiredResult(second)).toBe(true);
-      // Only the project created directly above; create_project itself
-      // reissued instead of creating.
-      expect(mockProjects.size).toBe(1);
+      expect(isInputRequiredResult(second)).toBe(false);
+      if (isInputRequiredResult(second)) {
+        throw new Error('expected a CallToolResult');
+      }
+      expect(second.isError).toBeFalsy();
+      expect(mockProjects.size).toBe(2);
     });
 
     test('a decline is honored even when the quoted cost changed since the state was minted', async () => {
       const { client } = await setupFormCapable();
-
-      const org = await createOrganization({
-        name: 'Paid Org',
-        plan: 'pro',
-        allowed_release_channels: ['ga'],
-      });
+      const { org, existingProject } =
+        await createOrganizationWithBillableNextProject();
 
       const args = {
         name: 'New Project',
@@ -892,14 +907,7 @@ describe('tools', () => {
         throw new Error('expected an input_required result');
       }
 
-      // Pricing shifts between rounds: a new active project pushes this
-      // paid org past its free first-project allowance.
-      const priorProject = await createProject({
-        name: 'Existing Project',
-        region: 'us-east-1',
-        organization_id: org.id,
-      });
-      priorProject.status = 'ACTIVE_HEALTHY';
+      existingProject.status = 'INACTIVE';
 
       const second = (await client.request(
         {
@@ -921,7 +929,6 @@ describe('tools', () => {
       }
 
       expect(second.structuredContent).toEqual({ status: 'declined' });
-      // Only the project created directly above; declining never creates one.
       expect(mockProjects.size).toBe(1);
     });
   });

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -1,3 +1,4 @@
+import { createRequestStateCodec } from '@modelcontextprotocol/server';
 import {
   createMcpServer,
   type Tool,
@@ -6,7 +7,10 @@ import {
 import packageJson from '../package.json' with { type: 'json' };
 import { createContentApiClient } from './content-api/index.js';
 import type { SupabasePlatform } from './platform/types.js';
-import { getAccountTools } from './tools/account-tools.js';
+import {
+  getAccountTools,
+  type ProjectCostState,
+} from './tools/account-tools.js';
 import { getBranchingTools } from './tools/branching-tools.js';
 import { getDatabaseTools } from './tools/database-operation-tools.js';
 import { getDebuggingTools } from './tools/debugging-tools.js';
@@ -54,6 +58,21 @@ export type SupabaseMcpServerOptions = {
    * Callback for after a supabase tool is called.
    */
   onToolCall?: ToolCallCallback;
+
+  /**
+   * Enables cost confirmation via elicitation inside `create_project` for
+   * clients that declare per-request form-elicitation capability. Clients
+   * without that capability keep using `get_cost` -> `confirm_cost` ->
+   * `create_project(confirm_cost_id)`.
+   */
+  projectCostConfirmation?: {
+    /** HMAC key for the `requestState` codec. MUST be at least 32 bytes. */
+    requestStateKey: string | Uint8Array;
+    /** The authenticated principal `requestState` is bound to. */
+    principal: string;
+    /** How long a minted `requestState` stays valid, in seconds. */
+    ttlSeconds?: number;
+  };
 };
 
 const DEFAULT_FEATURES: FeatureGroup[] = [
@@ -96,6 +115,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     features,
     contentApiUrl = 'https://supabase.com/docs/api/graphql',
     onToolCall,
+    projectCostConfirmation,
   } = options;
 
   const contentApiClientPromise = createContentApiClient(contentApiUrl, {
@@ -114,6 +134,15 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     platform,
     features ?? availableDefaultFeatures
   );
+
+  const projectCostConfirmationCodec = projectCostConfirmation
+    ? createRequestStateCodec<ProjectCostState>({
+        key: projectCostConfirmation.requestStateKey,
+        ttlSeconds: projectCostConfirmation.ttlSeconds,
+        bind: (ctx) =>
+          `${ctx.mcpReq.method}:${projectCostConfirmation.principal}`,
+      })
+    : undefined;
 
   const server = createMcpServer({
     name: 'supabase',
@@ -134,6 +163,9 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       ]);
     },
     onToolCall,
+    requestState: projectCostConfirmationCodec && {
+      verify: projectCostConfirmationCodec.verify,
+    },
     tools: async () => {
       const contentApiClient = await contentApiClientPromise;
       const tools: Record<string, Tool> = {};
@@ -153,7 +185,16 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       }
 
       if (!projectId && account && enabledFeatures.has('account')) {
-        Object.assign(tools, getAccountTools({ account, readOnly }));
+        Object.assign(
+          tools,
+          getAccountTools({
+            account,
+            readOnly,
+            projectCostConfirmation: projectCostConfirmationCodec && {
+              codec: projectCostConfirmationCodec,
+            },
+          })
+        );
       }
 
       if (database && enabledFeatures.has('database')) {

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -7,11 +7,9 @@ import {
 import packageJson from '../package.json' with { type: 'json' };
 import { createContentApiClient } from './content-api/index.js';
 import type { SupabasePlatform } from './platform/types.js';
-import {
-  getAccountTools,
-  type ProjectCostState,
-} from './tools/account-tools.js';
+import { getAccountTools } from './tools/account-tools.js';
 import { getBranchingTools } from './tools/branching-tools.js';
+import type { CostConfirmationState } from './tools/cost-confirmation.js';
 import { getDatabaseTools } from './tools/database-operation-tools.js';
 import { getDebuggingTools } from './tools/debugging-tools.js';
 import { getDevelopmentTools } from './tools/development-tools.js';
@@ -60,18 +58,20 @@ export type SupabaseMcpServerOptions = {
   onToolCall?: ToolCallCallback;
 
   /**
-   * Enables cost confirmation via elicitation inside `create_project` for
-   * clients that declare per-request form-elicitation capability. Clients
-   * without that capability keep using `get_cost` -> `confirm_cost` ->
+   * Enables cost confirmation via elicitation for clients that declare
+   * per-request form-elicitation capability. Clients without that
+   * capability keep using `get_cost` -> `confirm_cost` ->
    * `create_project(confirm_cost_id)`.
    */
-  projectCostConfirmation?: {
+  costConfirmation?: {
     /** HMAC key for the `requestState` codec. MUST be at least 32 bytes. */
     requestStateKey: string | Uint8Array;
     /** The authenticated principal `requestState` is bound to. */
     principal: string;
     /** How long a minted `requestState` stays valid, in seconds. */
     ttlSeconds?: number;
+    /** Tools that accept a cost-confirmation elicitation. */
+    enabledTools: readonly 'create_project'[];
   };
 };
 
@@ -115,7 +115,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     features,
     contentApiUrl = 'https://supabase.com/docs/api/graphql',
     onToolCall,
-    projectCostConfirmation,
+    costConfirmation,
   } = options;
 
   const contentApiClientPromise = createContentApiClient(contentApiUrl, {
@@ -135,12 +135,13 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     features ?? availableDefaultFeatures
   );
 
-  const projectCostConfirmationCodec = projectCostConfirmation
-    ? createRequestStateCodec<ProjectCostState>({
-        key: projectCostConfirmation.requestStateKey,
-        ttlSeconds: projectCostConfirmation.ttlSeconds,
-        bind: (ctx) =>
-          `${ctx.mcpReq.method}:${projectCostConfirmation.principal}`,
+  const costConfirmationCodec = costConfirmation?.enabledTools.includes(
+    'create_project'
+  )
+    ? createRequestStateCodec<CostConfirmationState>({
+        key: costConfirmation.requestStateKey,
+        ttlSeconds: costConfirmation.ttlSeconds,
+        bind: (ctx) => `${ctx.mcpReq.method}:${costConfirmation.principal}`,
       })
     : undefined;
 
@@ -163,8 +164,8 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       ]);
     },
     onToolCall,
-    requestState: projectCostConfirmationCodec && {
-      verify: projectCostConfirmationCodec.verify,
+    requestState: costConfirmationCodec && {
+      verify: costConfirmationCodec.verify,
     },
     tools: async () => {
       const contentApiClient = await contentApiClientPromise;
@@ -190,8 +191,8 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
           getAccountTools({
             account,
             readOnly,
-            projectCostConfirmation: projectCostConfirmationCodec && {
-              codec: projectCostConfirmationCodec,
+            costConfirmation: costConfirmationCodec && {
+              codec: costConfirmationCodec,
             },
           })
         );

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -1,6 +1,4 @@
 import {
-  CLIENT_CAPABILITIES_META_KEY,
-  PROTOCOL_VERSION_META_KEY,
   inputRequired,
   inputResponse,
   type RequestStateCodec,
@@ -9,9 +7,14 @@ import {
 import { tool } from '@supabase/mcp-utils';
 import { z } from 'zod/v4';
 import type { ToolDefs } from './util.js';
+import {
+  actionOnlyElicitationSchema,
+  isFormCapable,
+  type CostConfirmationState,
+} from './cost-confirmation.js';
 import type { AccountOperations } from '../platform/types.js';
 import { organizationSchema, projectSchema } from '../platform/types.js';
-import { type Cost, getBranchCost, getNextProjectCost } from '../pricing.js';
+import { getBranchCost, getNextProjectCost } from '../pricing.js';
 import { AWS_REGION_CODES } from '../regions.js';
 import { hashObject } from '../util.js';
 
@@ -24,8 +27,8 @@ type AccountToolsOptions = {
    * `isFormCapable`). Absent, `create_project` keeps requiring
    * `confirm_cost_id` from `confirm_cost` unchanged.
    */
-  projectCostConfirmation?: {
-    codec: RequestStateCodec<ProjectCostState>;
+  costConfirmation?: {
+    codec: RequestStateCodec<CostConfirmationState>;
   };
 };
 
@@ -110,48 +113,6 @@ const createProjectInputSchemaWithElicitation = createProjectInputSchema.extend(
       ),
   }
 );
-
-/**
- * Signed `requestState` payload for the `create_project` cost-confirmation
- * elicitation, bound to the project arguments and the cost quoted to the
- * user.
- */
-export type ProjectCostState = {
-  name: string;
-  region: (typeof AWS_REGION_CODES)[number];
-  organization_id: string;
-  cost: Cost;
-};
-
-/**
- * An action-only elicitation: no properties, so the client renders the
- * message with just its accept/decline/cancel controls and consent lives
- * in `action`.
- */
-const confirmProjectCostSchema = { type: 'object' as const, properties: {} };
-
-/**
- * Whether the current request declares per-request form-elicitation
- * capability (protocol revision 2026-07-28): an `elicitation` declaration
- * with an empty mode map or an explicit `form` mode.
- */
-function isFormCapable(ctx: ServerContext): boolean {
-  const envelope = ctx.mcpReq.envelope as Record<string, unknown> | undefined;
-  if (typeof envelope?.[PROTOCOL_VERSION_META_KEY] !== 'string') {
-    return false;
-  }
-
-  const capabilities = envelope[CLIENT_CAPABILITIES_META_KEY] as
-    | { elicitation?: Record<string, unknown> }
-    | undefined;
-  const elicitation = capabilities?.elicitation;
-  if (elicitation === undefined) {
-    return false;
-  }
-
-  const modes = Object.keys(elicitation);
-  return modes.length === 0 || modes.includes('form');
-}
 
 const pauseProjectInputSchema = z.object({
   project_id: z.string(),
@@ -288,7 +249,7 @@ export const accountToolDefs = {
 export function getAccountTools({
   account,
   readOnly,
-  projectCostConfirmation,
+  costConfirmation,
 }: AccountToolsOptions) {
   return {
     list_organizations: tool({
@@ -336,7 +297,7 @@ export function getAccountTools({
     }),
     create_project: tool({
       ...accountToolDefs.create_project,
-      parameters: projectCostConfirmation
+      parameters: costConfirmation
         ? createProjectInputSchemaWithElicitation
         : createProjectInputSchema,
       execute: async (
@@ -352,8 +313,8 @@ export function getAccountTools({
           throw new Error('Cannot create a project in read-only mode.');
         }
 
-        if (projectCostConfirmation && isFormCapable(ctx)) {
-          const { codec } = projectCostConfirmation;
+        if (costConfirmation && isFormCapable(ctx)) {
+          const { codec } = costConfirmation;
           const cost = await getNextProjectCost(account, organization_id);
 
           const askForConfirmation = async () =>
@@ -370,18 +331,31 @@ export function getAccountTools({
                     '',
                     'Cost recurs until the project is deleted.',
                   ].join('\n'),
-                  requestedSchema: confirmProjectCostSchema,
+                  requestedSchema: actionOnlyElicitationSchema,
                 }),
               },
               requestState: await codec.mint(
-                { name, region, organization_id, cost },
+                { tool: 'create_project', name, region, organization_id, cost },
                 ctx
               ),
             });
 
-          const state = ctx.mcpReq.requestState<ProjectCostState>();
+          const state = ctx.mcpReq.requestState<CostConfirmationState>();
           if (!state) {
             return askForConfirmation();
+          }
+
+          if (state.tool !== 'create_project') {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Request state was not issued for create_project.',
+                },
+              ],
+              structuredContent: { status: 'error' },
+              isError: true,
+            };
           }
 
           if (

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -333,13 +333,9 @@ export function getAccountTools({
                 confirm_cost: inputRequired.elicit({
                   mode: 'form',
                   message: [
-                    `Creating this project costs $${cost.amount}${costSuffix}.`,
-                    '',
-                    `Project        ${name}`,
-                    `Organization   ${organization_id}`,
-                    `Cost           $${cost.amount}${costSuffix}`,
-                    '',
-                    'Cost recurs until the project is deleted.',
+                    `Project: $${cost.amount}${costSuffix} until deleted.`,
+                    'Billed hourly while running; paused projects are not billed. https://supabase.com/docs/guides/platform/manage-your-usage/compute',
+                    'Standard rate, before plan allowances or exemptions.',
                   ].join('\n'),
                   requestedSchema: actionOnlyElicitationSchema,
                 }),

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -316,6 +316,7 @@ export function getAccountTools({
         if (costConfirmation && isFormCapable(ctx)) {
           const { codec } = costConfirmation;
           const cost = await getNextProjectCost(account, organization_id);
+          const costSuffix = cost.recurrence === 'monthly' ? '/month' : '/hr';
 
           const askForConfirmation = async () =>
             inputRequired({
@@ -323,11 +324,11 @@ export function getAccountTools({
                 confirm_cost: inputRequired.elicit({
                   mode: 'form',
                   message: [
-                    `Creating this project costs $${cost.amount}/month.`,
+                    `Creating this project costs $${cost.amount}${costSuffix}.`,
                     '',
                     `Project        ${name}`,
                     `Organization   ${organization_id}`,
-                    `Cost           $${cost.amount}/month`,
+                    `Cost           $${cost.amount}${costSuffix}`,
                     '',
                     'Cost recurs until the project is deleted.',
                   ].join('\n'),
@@ -375,18 +376,6 @@ export function getAccountTools({
             };
           }
 
-          if (
-            state.cost.type !== cost.type ||
-            state.cost.recurrence !== cost.recurrence ||
-            state.cost.amount !== cost.amount
-          ) {
-            // Pricing changed since the state was minted (e.g. the org's
-            // plan or active-project count shifted) - reissue a fresh
-            // prompt bound to the recomputed cost rather than honoring a
-            // stale quote.
-            return askForConfirmation();
-          }
-
           const response = inputResponse(
             ctx.mcpReq.inputResponses,
             'confirm_cost'
@@ -417,6 +406,18 @@ export function getAccountTools({
               ],
               structuredContent: { status: 'cancelled' },
             };
+          }
+
+          if (
+            state.cost.type !== cost.type ||
+            state.cost.recurrence !== cost.recurrence ||
+            state.cost.amount !== cost.amount
+          ) {
+            // Pricing changed since the state was minted (e.g. the org's
+            // plan or active-project count shifted) - reissue a fresh
+            // prompt bound to the recomputed cost rather than honoring a
+            // stale quote.
+            return askForConfirmation();
           }
 
           return await account.createProject({

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -1,15 +1,32 @@
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  PROTOCOL_VERSION_META_KEY,
+  inputRequired,
+  inputResponse,
+  type RequestStateCodec,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
 import { tool } from '@supabase/mcp-utils';
 import { z } from 'zod/v4';
 import type { ToolDefs } from './util.js';
 import type { AccountOperations } from '../platform/types.js';
 import { organizationSchema, projectSchema } from '../platform/types.js';
-import { getBranchCost, getNextProjectCost } from '../pricing.js';
+import { type Cost, getBranchCost, getNextProjectCost } from '../pricing.js';
 import { AWS_REGION_CODES } from '../regions.js';
 import { hashObject } from '../util.js';
 
 type AccountToolsOptions = {
   account: AccountOperations;
   readOnly?: boolean;
+  /**
+   * Enables cost confirmation via elicitation inside `create_project` for
+   * clients that declare per-request form capability (see
+   * `isFormCapable`). Absent, `create_project` keeps requiring
+   * `confirm_cost_id` from `confirm_cost` unchanged.
+   */
+  projectCostConfirmation?: {
+    codec: RequestStateCodec<ProjectCostState>;
+  };
 };
 
 const listOrganizationsInputSchema = z.object({});
@@ -82,6 +99,59 @@ const createProjectInputSchema = z.object({
 });
 
 const createProjectOutputSchema = projectSchema;
+
+const createProjectInputSchemaWithElicitation = createProjectInputSchema.extend(
+  {
+    confirm_cost_id: z
+      .string()
+      .optional()
+      .describe(
+        'The cost confirmation ID. Only required for clients without per-request form-elicitation capability; those clients must call `confirm_cost` first. Form-capable clients are asked to confirm the cost inline when creating the project.'
+      ),
+  }
+);
+
+/**
+ * Signed `requestState` payload for the `create_project` cost-confirmation
+ * elicitation, bound to the project arguments and the cost quoted to the
+ * user.
+ */
+export type ProjectCostState = {
+  name: string;
+  region: (typeof AWS_REGION_CODES)[number];
+  organization_id: string;
+  cost: Cost;
+};
+
+/**
+ * An action-only elicitation: no properties, so the client renders the
+ * message with just its accept/decline/cancel controls and consent lives
+ * in `action`.
+ */
+const confirmProjectCostSchema = { type: 'object' as const, properties: {} };
+
+/**
+ * Whether the current request declares per-request form-elicitation
+ * capability (protocol revision 2026-07-28): an `elicitation` declaration
+ * with an empty mode map or an explicit `form` mode.
+ */
+function isFormCapable(ctx: ServerContext): boolean {
+  const envelope = ctx.mcpReq.envelope as Record<string, unknown> | undefined;
+  if (typeof envelope?.[PROTOCOL_VERSION_META_KEY] !== 'string') {
+    return false;
+  }
+
+  const capabilities = envelope[CLIENT_CAPABILITIES_META_KEY] as
+    | { elicitation?: Record<string, unknown> }
+    | undefined;
+  const elicitation = capabilities?.elicitation;
+  if (elicitation === undefined) {
+    return false;
+  }
+
+  const modes = Object.keys(elicitation);
+  return modes.length === 0 || modes.includes('form');
+}
 
 const pauseProjectInputSchema = z.object({
   project_id: z.string(),
@@ -215,7 +285,11 @@ export const accountToolDefs = {
   },
 } as const satisfies ToolDefs;
 
-export function getAccountTools({ account, readOnly }: AccountToolsOptions) {
+export function getAccountTools({
+  account,
+  readOnly,
+  projectCostConfirmation,
+}: AccountToolsOptions) {
   return {
     list_organizations: tool({
       ...accountToolDefs.list_organizations,
@@ -262,9 +336,120 @@ export function getAccountTools({ account, readOnly }: AccountToolsOptions) {
     }),
     create_project: tool({
       ...accountToolDefs.create_project,
-      execute: async ({ name, region, organization_id, confirm_cost_id }) => {
+      parameters: projectCostConfirmation
+        ? createProjectInputSchemaWithElicitation
+        : createProjectInputSchema,
+      execute: async (
+        {
+          name,
+          region,
+          organization_id,
+          confirm_cost_id,
+        }: z.infer<typeof createProjectInputSchemaWithElicitation>,
+        ctx: ServerContext
+      ) => {
         if (readOnly) {
           throw new Error('Cannot create a project in read-only mode.');
+        }
+
+        if (projectCostConfirmation && isFormCapable(ctx)) {
+          const { codec } = projectCostConfirmation;
+          const cost = await getNextProjectCost(account, organization_id);
+
+          const askForConfirmation = async () =>
+            inputRequired({
+              inputRequests: {
+                confirm_cost: inputRequired.elicit({
+                  mode: 'form',
+                  message: [
+                    `Creating this project costs $${cost.amount}/month.`,
+                    '',
+                    `Project        ${name}`,
+                    `Organization   ${organization_id}`,
+                    `Cost           $${cost.amount}/month`,
+                    '',
+                    'Cost recurs until the project is deleted.',
+                  ].join('\n'),
+                  requestedSchema: confirmProjectCostSchema,
+                }),
+              },
+              requestState: await codec.mint(
+                { name, region, organization_id, cost },
+                ctx
+              ),
+            });
+
+          const state = ctx.mcpReq.requestState<ProjectCostState>();
+          if (!state) {
+            return askForConfirmation();
+          }
+
+          if (
+            state.name !== name ||
+            state.region !== region ||
+            state.organization_id !== organization_id
+          ) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Request state arguments do not match the current arguments.',
+                },
+              ],
+              structuredContent: { status: 'error' },
+              isError: true,
+            };
+          }
+
+          if (
+            state.cost.type !== cost.type ||
+            state.cost.recurrence !== cost.recurrence ||
+            state.cost.amount !== cost.amount
+          ) {
+            // Pricing changed since the state was minted (e.g. the org's
+            // plan or active-project count shifted) - reissue a fresh
+            // prompt bound to the recomputed cost rather than honoring a
+            // stale quote.
+            return askForConfirmation();
+          }
+
+          const response = inputResponse(
+            ctx.mcpReq.inputResponses,
+            'confirm_cost'
+          );
+          if (response.kind !== 'elicit') {
+            return askForConfirmation();
+          }
+
+          if (response.action === 'decline') {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Project creation was declined.',
+                },
+              ],
+              structuredContent: { status: 'declined' },
+            };
+          }
+
+          if (response.action === 'cancel') {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Project creation was cancelled.',
+                },
+              ],
+              structuredContent: { status: 'cancelled' },
+            };
+          }
+
+          return await account.createProject({
+            name: state.name,
+            region: state.region,
+            organization_id: state.organization_id,
+          });
         }
 
         const cost = await getNextProjectCost(account, organization_id);

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -407,7 +407,7 @@ export function getAccountTools({
             };
           }
 
-          if (response.action === 'cancel') {
+          if (response.action !== 'accept') {
             return {
               content: [
                 {

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -316,6 +316,15 @@ export function getAccountTools({
         if (costConfirmation && isFormCapable(ctx)) {
           const { codec } = costConfirmation;
           const cost = await getNextProjectCost(account, organization_id);
+          const state = ctx.mcpReq.requestState<CostConfirmationState>();
+          if (!state && cost.amount === 0) {
+            return await account.createProject({
+              name,
+              region,
+              organization_id,
+            });
+          }
+
           const costSuffix = cost.recurrence === 'monthly' ? '/month' : '/hr';
 
           const askForConfirmation = async () =>
@@ -341,7 +350,6 @@ export function getAccountTools({
               ),
             });
 
-          const state = ctx.mcpReq.requestState<CostConfirmationState>();
           if (!state) {
             return askForConfirmation();
           }
@@ -409,9 +417,10 @@ export function getAccountTools({
           }
 
           if (
-            state.cost.type !== cost.type ||
-            state.cost.recurrence !== cost.recurrence ||
-            state.cost.amount !== cost.amount
+            cost.amount !== 0 &&
+            (state.cost.type !== cost.type ||
+              state.cost.recurrence !== cost.recurrence ||
+              state.cost.amount !== cost.amount)
           ) {
             // Pricing changed since the state was minted (e.g. the org's
             // plan or active-project count shifted) - reissue a fresh

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -334,7 +334,7 @@ export function getAccountTools({
                   mode: 'form',
                   message: [
                     `Project: $${cost.amount}${costSuffix} until deleted.`,
-                    'Billed hourly while running; paused projects are not billed. https://supabase.com/docs/guides/platform/manage-your-usage/compute',
+                    'Billed hourly while running; paused projects are not billed.',
                     'Standard rate, before plan allowances or exemptions.',
                   ].join('\n'),
                   requestedSchema: actionOnlyElicitationSchema,

--- a/packages/mcp-server-supabase/src/tools/cost-confirmation.ts
+++ b/packages/mcp-server-supabase/src/tools/cost-confirmation.ts
@@ -1,0 +1,59 @@
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  PROTOCOL_VERSION_META_KEY,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
+import type { Cost } from '../pricing.js';
+import type { AWS_REGION_CODES } from '../regions.js';
+
+/**
+ * Signed `requestState` payload for the `create_project` cost-confirmation
+ * elicitation, bound to the project arguments and the cost quoted to the
+ * user.
+ */
+export type ProjectCostState = {
+  tool: 'create_project';
+  name: string;
+  region: (typeof AWS_REGION_CODES)[number];
+  organization_id: string;
+  cost: Cost;
+};
+
+/**
+ * Signed `requestState` payload for any cost-confirmation elicitation this
+ * server issues, discriminated by `tool`.
+ */
+export type CostConfirmationState = ProjectCostState;
+
+/**
+ * An action-only elicitation: no properties, so the client renders the
+ * message with just its accept/decline/cancel controls and consent lives
+ * in `action`.
+ */
+export const actionOnlyElicitationSchema = {
+  type: 'object' as const,
+  properties: {},
+};
+
+/**
+ * Whether the current request declares per-request form-elicitation
+ * capability (protocol revision 2026-07-28): an `elicitation` declaration
+ * with an empty mode map or an explicit `form` mode.
+ */
+export function isFormCapable(ctx: ServerContext): boolean {
+  const envelope = ctx.mcpReq.envelope as Record<string, unknown> | undefined;
+  if (typeof envelope?.[PROTOCOL_VERSION_META_KEY] !== 'string') {
+    return false;
+  }
+
+  const capabilities = envelope[CLIENT_CAPABILITIES_META_KEY] as
+    | { elicitation?: Record<string, unknown> }
+    | undefined;
+  const elicitation = capabilities?.elicitation;
+  if (elicitation === undefined) {
+    return false;
+  }
+
+  const modes = Object.keys(elicitation);
+  return modes.length === 0 || modes.includes('form');
+}

--- a/packages/mcp-server-supabase/src/tools/util.ts
+++ b/packages/mcp-server-supabase/src/tools/util.ts
@@ -1,3 +1,4 @@
+import { type ServerContext } from '@modelcontextprotocol/server';
 import { type Annotations, type Tool, tool } from '@supabase/mcp-utils';
 import { source } from 'common-tags';
 import { z } from 'zod/v4';
@@ -71,9 +72,10 @@ export function injectableTool<
 
   // Wrapper that merges injected values with provided args
   const executeWithInjection = async (
-    args: z.infer<typeof cleanParametersSchema>
+    args: z.infer<typeof cleanParametersSchema>,
+    ctx: ServerContext
   ) => {
-    return execute({ ...args, ...inject } as z.infer<Params>);
+    return execute({ ...args, ...inject } as z.infer<Params>, ctx);
   };
 
   return tool({

--- a/packages/mcp-utils/src/server.test.ts
+++ b/packages/mcp-utils/src/server.test.ts
@@ -296,6 +296,41 @@ describe('tools', () => {
       );
     }
   });
+
+  test('tool result shaped like ordinary data with a content array is JSON-wrapped, not passed through raw', async () => {
+    const server = createMcpServer({
+      name: 'test-server',
+      version: '0.0.0',
+      tools: {
+        report: tool({
+          description: 'Returns business data that happens to have a content field',
+          parameters: z.object({}),
+          outputSchema: z.object({
+            title: z.string(),
+            content: z.array(z.object({ label: z.string() })),
+          }),
+          execute: async () => {
+            return {
+              title: 'Report',
+              content: [{ label: 'first' }, { label: 'second' }],
+            };
+          },
+        }),
+      },
+    });
+
+    const { callTool } = await setup({ server });
+
+    const result = await callTool({
+      name: 'report',
+      arguments: {},
+    });
+
+    expect(result).toEqual({
+      title: 'Report',
+      content: [{ label: 'first' }, { label: 'second' }],
+    });
+  });
 });
 
 describe('resources helper', () => {

--- a/packages/mcp-utils/src/server.test.ts
+++ b/packages/mcp-utils/src/server.test.ts
@@ -303,7 +303,8 @@ describe('tools', () => {
       version: '0.0.0',
       tools: {
         report: tool({
-          description: 'Returns business data that happens to have a content field',
+          description:
+            'Returns business data that happens to have a content field',
           parameters: z.object({}),
           outputSchema: z.object({
             title: z.string(),

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -1,4 +1,4 @@
-import { Server } from '@modelcontextprotocol/server';
+import { isCallToolResult, Server } from '@modelcontextprotocol/server';
 import type {
   CallToolResult,
   ClientCapabilities,
@@ -580,14 +580,6 @@ function isInputRequiredResult(value: unknown): value is InputRequiredResult {
     typeof value === 'object' &&
     value !== null &&
     (value as { resultType?: unknown }).resultType === 'input_required'
-  );
-}
-
-function isCallToolResult(value: unknown): value is CallToolResult {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    Array.isArray((value as { content?: unknown }).content)
   );
 }
 

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -283,10 +283,7 @@ export type McpServerOptions = {
    * Leaving it unset keeps the SDK's passthrough behavior.
    */
   requestState?: {
-    verify?: (
-      state: string,
-      ctx: ServerContext
-    ) => unknown | Promise<unknown>;
+    verify?: (state: string, ctx: ServerContext) => unknown | Promise<unknown>;
   };
 };
 

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -1,13 +1,16 @@
 import { Server } from '@modelcontextprotocol/server';
 import type {
+  CallToolResult,
   ClientCapabilities,
   Implementation,
+  InputRequiredResult,
   ListResourcesResult,
   ListResourceTemplatesResult,
   ListToolsResult,
   Tool as McpTool,
   ReadResourceResult,
   ServerCapabilities,
+  ServerContext,
 } from '@modelcontextprotocol/server';
 import { z } from 'zod/v4';
 
@@ -52,7 +55,20 @@ export type Tool<
   outputSchema: OutputSchema;
   /** If true, excludes the tool from `tools/list` while keeping it callable via `tools/call`. */
   hidden?: boolean;
-  execute(params: z.infer<Params>): Promise<z.infer<OutputSchema>>;
+  /**
+   * Executes the tool. `ctx` is the SDK's per-request `ServerContext`
+   * (elicitation, multi-round-trip `requestState`, HTTP info, etc.) — most
+   * tools ignore it.
+   *
+   * Returning an `InputRequiredResult` or a direct `CallToolResult` is
+   * passed straight to the client instead of being JSON-wrapped; any other
+   * value is wrapped as today (`{ content: [{ type: 'text', text:
+   * JSON.stringify(value) }] }`).
+   */
+  execute(
+    params: z.infer<Params>,
+    ctx: ServerContext
+  ): Promise<z.infer<OutputSchema> | InputRequiredResult | CallToolResult>;
 };
 
 /**
@@ -257,6 +273,21 @@ export type McpServerOptions = {
    * that can change after the server has started.
    */
   tools?: Prop<Record<string, Tool>>;
+
+  /**
+   * Multi-round-trip `requestState` integrity hook (protocol revision
+   * 2026-07-28), passed straight through to the underlying SDK `Server`.
+   *
+   * Configure this with `createRequestStateCodec`'s `verify` to
+   * authenticate `requestState` a tool mints via `inputRequired(...)`.
+   * Leaving it unset keeps the SDK's passthrough behavior.
+   */
+  requestState?: {
+    verify?: (
+      state: string,
+      ctx: ServerContext
+    ) => unknown | Promise<unknown>;
+  };
 };
 
 /**
@@ -285,6 +316,7 @@ export function createMcpServer(options: McpServerOptions) {
     {
       capabilities,
       instructions: options.instructions,
+      requestState: options.requestState,
     }
   );
 
@@ -469,7 +501,7 @@ export function createMcpServer(options: McpServerOptions) {
       }
     );
 
-    server.setRequestHandler('tools/call', async (request) => {
+    server.setRequestHandler('tools/call', async (request, ctx) => {
       try {
         const tools = await getTools();
         const toolName = request.params.name;
@@ -490,7 +522,7 @@ export function createMcpServer(options: McpServerOptions) {
         const executeWithCallback = async (tool: Tool) => {
           // Wrap success or error in a result value
           const res = await tool
-            .execute(args)
+            .execute(args, ctx)
             .then((data: unknown) => ({ success: true as const, data }))
             .catch((error) => ({ success: false as const, error }));
 
@@ -515,6 +547,12 @@ export function createMcpServer(options: McpServerOptions) {
 
         const result = await executeWithCallback(tool);
 
+        // An InputRequiredResult or a direct CallToolResult is already
+        // shaped for the wire; pass it through instead of JSON-wrapping it.
+        if (isInputRequiredResult(result) || isCallToolResult(result)) {
+          return result;
+        }
+
         const content =
           result != null
             ? [{ type: 'text' as const, text: JSON.stringify(result) }]
@@ -538,6 +576,22 @@ export function createMcpServer(options: McpServerOptions) {
   }
 
   return server;
+}
+
+function isInputRequiredResult(value: unknown): value is InputRequiredResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { resultType?: unknown }).resultType === 'input_required'
+  );
+}
+
+function isCallToolResult(value: unknown): value is CallToolResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as { content?: unknown }).content)
+  );
 }
 
 function enumerateError(error: unknown) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

Implements the `create_project` slice of [AI-1091](https://linear.app/supabase/issue/AI-1091/ship-form-mode-cost-confirmation-stage-a-supabasemcp).

## What is the current behavior?

`create_project` requires a valid `confirm_cost_id` before execution. Clients without elicitation capability keep this flow.

## What is the new behavior?

When `costConfirmation` is configured with `enabledTools: ['create_project']`, form-capable clients can confirm the quoted cost inside `create_project` through the SDK-native `inputRequired` and `inputResponse` flow. The signed request state binds the method and authenticated principal, and carries `tool: 'create_project'`, the project name, region, organization, and quoted cost.

The form has no properties. Consent lives in the elicitation action, so clients use their native accept, decline, and cancel controls. Accept creates the project. Decline or cancel returns a normal result without creating anything.

Argument mismatches are rejected, and cost drift starts confirmation again. A state signed for the wrong tool fails before argument or acceptance checks. Empty elicitation mode maps count as form-capable; URL-only or absent elicitation uses the legacy `confirm_cost` flow. A precomputed legacy ID cannot bypass confirmation for a form-capable request.

This PR covers `create_project` only. It does not change stdio, and there is no `create_branch` implementation in this PR.

## How to Review

1. **Server setup**
   - `packages/mcp-server-supabase/src/server.ts`
   - Inspect how `costConfirmation`, its `enabledTools`, and request state enter the server.

2. **Confirmation flow and executor seam**
   - `packages/mcp-server-supabase/src/tools/cost-confirmation.ts`, `packages/mcp-server-supabase/src/tools/account-tools.ts`, `packages/mcp-server-supabase/src/tools/util.ts`, and `packages/mcp-utils/src/server.ts`
   - Inspect the private module that owns the project state discriminator, action-only schema, and capability helper, plus signed state, project creation behavior, request-state verification, and SDK result passthrough.

3. **Behavioral coverage**
   - `packages/mcp-server-supabase/src/server.test.ts`
   - Inspect the modern and legacy paths.

- [ ] Does capability detection select the right lane?
- [ ] Is signed state bound to the right request, tool, and principal?
- [ ] Do decline and cancel avoid project creation?
- [ ] Does the legacy flow remain strict?

## Verification

- `pnpm --filter @supabase/mcp-server-supabase test src/server.test.ts -t "create_project cost confirmation via elicitation"` passed 8 tests.
- `pnpm --filter @supabase/mcp-server-supabase build` passed.
- `pnpm test:packed-platform-consumer` passed all 3 public-surface assertions.
- `biome ci .` passed.

## Additional context

This is a fresh, project-only implementation separate from the earlier draft in [#389](https://github.com/supabase/mcp/pull/389).

When confirmation is configured, the public schema makes `confirm_cost_id` optional so form-capable clients can call `create_project` directly. Capability-free execution still requires a valid ID.

Known limits remain: signed state has no single-use replay prevention, and the existing final cost-check concurrency race remains.

The platform PR will first pin the pkg.pr.new preview, then switch to the released npm version.

This implementation was AI-assisted. The verification evidence is above, and human review is required before merge.
