### PR TITLE
feat(mcp): add branch cost confirmation elicitation

### DIFF
--- a/packages/mcp-server-supabase/src/pricing.ts
+++ b/packages/mcp-server-supabase/src/pricing.ts
@@ -48,6 +48,6 @@ export async function getNextProjectCost(
 /**
  * Gets the cost for a database branch.
  */
-export function getBranchCost(): Cost {
+export function getBranchCost(): BranchCost {
   return { type: 'branch', recurrence: 'hourly', amount: BRANCH_COST_HOURLY };
 }

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -3920,6 +3920,53 @@ describe('tools', () => {
       expect(mockBranches.size).toBe(0);
     });
 
+    test('form-capable client: a non-elicitation response re-prompts without creating a branch', async () => {
+      const { client } = await setupFormCapable();
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const args = { project_id: project.id, name: 'test-branch' };
+      const first = (await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'create_branch', arguments: args },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(first)) {
+        throw new Error('expected an input_required result');
+      }
+
+      const second = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_branch',
+            arguments: args,
+            inputResponses: {
+              confirm_cost: { roots: [] },
+            },
+            requestState: first.requestState,
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      expect(isInputRequiredResult(second)).toBe(true);
+      expect(mockBranches.size).toBe(0);
+    });
+
     test('a decline is honored even when the quoted branch cost changed since the state was minted', async () => {
       const getBranchCostSpy = vi
         .spyOn(pricing, 'getBranchCost')
@@ -3959,9 +4006,12 @@ describe('tools', () => {
       if (!isInputRequiredResult(first)) {
         throw new Error('expected an input_required result');
       }
-      expect(first.inputRequests.confirm_cost).toMatchObject({
-        mode: 'form',
-        message: expect.stringContaining(`$${BRANCH_COST_HOURLY}/hr`),
+      expect(first.inputRequests?.confirm_cost).toMatchObject({
+        method: 'elicitation/create',
+        params: {
+          mode: 'form',
+          message: expect.stringContaining(`$${BRANCH_COST_HOURLY}/hr`),
+        },
       });
 
       const second = (await client.request(

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4202,6 +4202,134 @@ describe('tools', () => {
         )
       ).toHaveLength(1);
     });
+
+    test('rejects a requestState minted by create_project', async () => {
+      const { client } = await setupFormCapable();
+
+      // create_project only triggers cost confirmation for a paid org's
+      // additional projects, so set up a pro org with one existing project.
+      const org = await createOrganization({
+        name: 'Paid Org',
+        plan: 'pro',
+        allowed_release_channels: ['ga'],
+      });
+      const existingProject = await createProject({
+        name: 'Existing Project',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      existingProject.status = 'ACTIVE_HEALTHY';
+
+      const projectFirst = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_project',
+            arguments: {
+              organization_id: org.id,
+              name: 'My Project',
+              region: 'us-east-1',
+            },
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(projectFirst)) {
+        throw new Error(
+          'expected an input_required result from create_project'
+        );
+      }
+
+      const result = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_branch',
+            arguments: { project_id: existingProject.id, name: 'test-branch' },
+            inputResponses: {
+              confirm_cost: { action: 'accept', content: {} },
+            },
+            requestState: projectFirst.requestState,
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (isInputRequiredResult(result)) {
+        throw new Error('expected a CallToolResult');
+      }
+
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toEqual({ status: 'error' });
+      expect(
+        result.content.some(
+          (c) =>
+            c.type === 'text' &&
+            c.text === 'Request state was not issued for create_branch.'
+        )
+      ).toBe(true);
+      expect(mockBranches.size).toBe(0);
+    });
+
+    test('rejects a tampered requestState before the handler runs', async () => {
+      const { client } = await setupFormCapable();
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const first = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_branch',
+            arguments: { project_id: project.id, name: 'test-branch' },
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(first)) {
+        throw new Error('expected an input_required result');
+      }
+
+      // Flip the last character to tamper the HMAC signature; the framework
+      // rejects it before the handler runs (ProtocolError -32602).
+      const originalState = first.requestState as string;
+      const lastChar = originalState.slice(-1);
+      const tamperedState =
+        originalState.slice(0, -1) + (lastChar === 'a' ? 'b' : 'a');
+
+      await expect(
+        client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'create_branch',
+              arguments: { project_id: project.id, name: 'test-branch' },
+              inputResponses: {
+                confirm_cost: { action: 'accept', content: {} },
+              },
+              requestState: tamperedState,
+            },
+          },
+          { allowInputRequired: true }
+        )
+      ).rejects.toMatchObject({
+        code: -32602,
+        message: 'Invalid or expired requestState',
+      });
+      expect(mockBranches.size).toBe(0);
+    });
   });
 
   test('delete branch', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -3980,61 +3980,64 @@ describe('tools', () => {
           recurrence: 'hourly',
           amount: BRANCH_COST_HOURLY + 1,
         });
-      const { client } = await setupFormCapable();
+      try {
+        const { client } = await setupFormCapable();
 
-      const org = await createOrganization({
-        name: 'My Org',
-        plan: 'free',
-        allowed_release_channels: ['ga'],
-      });
-      const project = await createProject({
-        name: 'Project 1',
-        region: 'us-east-1',
-        organization_id: org.id,
-      });
-      project.status = 'ACTIVE_HEALTHY';
+        const org = await createOrganization({
+          name: 'My Org',
+          plan: 'free',
+          allowed_release_channels: ['ga'],
+        });
+        const project = await createProject({
+          name: 'Project 1',
+          region: 'us-east-1',
+          organization_id: org.id,
+        });
+        project.status = 'ACTIVE_HEALTHY';
 
-      const args = { project_id: project.id, name: 'test-branch' };
-      const first = (await client.request(
-        {
-          method: 'tools/call',
-          params: { name: 'create_branch', arguments: args },
-        },
-        { allowInputRequired: true }
-      )) as CallToolResult | InputRequiredResult;
-
-      if (!isInputRequiredResult(first)) {
-        throw new Error('expected an input_required result');
-      }
-      expect(first.inputRequests?.confirm_cost).toMatchObject({
-        method: 'elicitation/create',
-        params: {
-          mode: 'form',
-          message: expect.stringContaining(`$${BRANCH_COST_HOURLY}/hr`),
-        },
-      });
-
-      const second = (await client.request(
-        {
-          method: 'tools/call',
-          params: {
-            name: 'create_branch',
-            arguments: args,
-            inputResponses: {
-              confirm_cost: { action: 'decline' },
-            },
-            requestState: first.requestState,
+        const args = { project_id: project.id, name: 'test-branch' };
+        const first = (await client.request(
+          {
+            method: 'tools/call',
+            params: { name: 'create_branch', arguments: args },
           },
-        },
-        { allowInputRequired: true }
-      )) as CallToolResult | InputRequiredResult;
-      getBranchCostSpy.mockRestore();
+          { allowInputRequired: true }
+        )) as CallToolResult | InputRequiredResult;
 
-      if (isInputRequiredResult(second)) {
-        throw new Error('expected a CallToolResult');
+        if (!isInputRequiredResult(first)) {
+          throw new Error('expected an input_required result');
+        }
+        expect(first.inputRequests?.confirm_cost).toMatchObject({
+          method: 'elicitation/create',
+          params: {
+            mode: 'form',
+            message: expect.stringContaining(`$${BRANCH_COST_HOURLY}/hr`),
+          },
+        });
+
+        const second = (await client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'create_branch',
+              arguments: args,
+              inputResponses: {
+                confirm_cost: { action: 'decline' },
+              },
+              requestState: first.requestState,
+            },
+          },
+          { allowInputRequired: true }
+        )) as CallToolResult | InputRequiredResult;
+
+        if (isInputRequiredResult(second)) {
+          throw new Error('expected a CallToolResult');
+        }
+        expect(second.structuredContent).toEqual({ status: 'declined' });
+        expect(mockBranches.size).toBe(0);
+      } finally {
+        getBranchCostSpy.mockRestore();
       }
-      expect(second.structuredContent).toEqual({ status: 'declined' });
-      expect(mockBranches.size).toBe(0);
     });
 
     test('form-capable client: a supplied confirm_cost_id cannot bypass the form', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -25,13 +25,18 @@ import {
   createProject,
   MCP_CLIENT_NAME,
   MCP_CLIENT_VERSION,
+  mockBranches,
   mockContentApiSchemaLoadCount,
   mockProjects,
   setupMockApis,
 } from '../test/mocks.js';
 import { createSupabaseApiPlatform } from './platform/api-platform.js';
 import type { SupabasePlatform } from './platform/types.js';
-import { BRANCH_COST_HOURLY, PROJECT_COST_MONTHLY } from './pricing.js';
+import {
+  BRANCH_COST_HOURLY,
+  getBranchCost,
+  PROJECT_COST_MONTHLY,
+} from './pricing.js';
 import {
   createSupabaseMcpServer,
   instructions,
@@ -42,6 +47,7 @@ import {
   supabaseMcpToolSchemas,
 } from './tools/tool-schemas.js';
 import { createSupabaseMcpHandler } from './transports/http.js';
+import { hashObject } from './util.js';
 
 let mockServer: SetupServer | undefined;
 
@@ -143,6 +149,7 @@ async function setup(options: SetupOptions = {}) {
 
 type FormCapableSetupOptions = {
   readOnly?: boolean;
+  projectId?: string;
   /**
    * Registers an auto-fulfilling `elicitation/create` handler that always
    * answers with this action, driven via `client.callTool`. Omit for manual
@@ -156,7 +163,7 @@ const COST_CONFIRMATION: NonNullable<
 > = {
   requestStateKey: 'a'.repeat(32),
   principal: 'test-user',
-  enabledTools: ['create_project'],
+  enabledTools: ['create_project', 'create_branch'],
 };
 
 // https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
@@ -165,14 +172,15 @@ const MCP_ENDPOINT = new URL('https://mcp.test');
 
 /**
  * Sets up an MCP client against the hosted HTTP handler (in-process, via a
- * custom `fetch`) for the `create_project` cost-confirmation elicitation
- * lane: a client pinned to the 2026-07-28 protocol, declaring per-request
- * form capability. Raw `StreamTransport` only speaks the 2025 era, so the
- * form-capable lane - which depends on the per-request `_meta` envelope -
- * needs the same in-process HTTP transport the hosted runtime uses.
+ * custom `fetch`) for the `create_project`/`create_branch` cost-confirmation
+ * elicitation lanes: a client pinned to the 2026-07-28 protocol, declaring
+ * per-request form capability. Raw `StreamTransport` only speaks the 2025
+ * era, so the form-capable lane - which depends on the per-request `_meta`
+ * envelope - needs the same in-process HTTP transport the hosted runtime
+ * uses.
  */
 async function setupFormCapable(options: FormCapableSetupOptions = {}) {
-  const { readOnly, elicitationAction } = options;
+  const { readOnly, projectId, elicitationAction } = options;
 
   const platform = createSupabaseApiPlatform({
     accessToken: ACCESS_TOKEN,
@@ -190,6 +198,7 @@ async function setupFormCapable(options: FormCapableSetupOptions = {}) {
 
   const handler = createSupabaseMcpHandler({
     platform,
+    projectId,
     readOnly,
     costConfirmation: COST_CONFIRMATION,
   });
@@ -3730,6 +3739,330 @@ describe('tools', () => {
     await expect(createBranchPromise).rejects.toThrow(
       'User must confirm understanding of costs before creating a branch.'
     );
+  });
+
+  describe('create_branch cost confirmation via elicitation', () => {
+    test('create_branch requires confirm_cost_id when cost confirmation is not configured', async () => {
+      const { client } = await setup({ features: ['branching'] });
+
+      const { tools } = await client.listTools();
+      const createBranchTool = tools.find(
+        (tool) => tool.name === 'create_branch'
+      );
+
+      expect(createBranchTool?.inputSchema.required).toContain(
+        'confirm_cost_id'
+      );
+    });
+
+    test('create_branch advertises confirm_cost_id as optional when cost confirmation is configured', async () => {
+      const { client } = await setup({
+        features: ['branching'],
+        costConfirmation: COST_CONFIRMATION,
+      });
+
+      const { tools } = await client.listTools();
+      const createBranchTool = tools.find(
+        (tool) => tool.name === 'create_branch'
+      );
+
+      expect(createBranchTool?.inputSchema.required).not.toContain(
+        'confirm_cost_id'
+      );
+    });
+
+    test('capability-free client still succeeds via get_cost -> confirm_cost -> create_branch', async () => {
+      const { callTool } = await setup({
+        features: ['account', 'branching'],
+        costConfirmation: COST_CONFIRMATION,
+      });
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const confirm_cost_id_result = await callTool({
+        name: 'confirm_cost',
+        arguments: {
+          type: 'branch',
+          recurrence: 'hourly',
+          amount: BRANCH_COST_HOURLY,
+        },
+      });
+
+      const branchName = 'test-branch';
+      const result = await callTool({
+        name: 'create_branch',
+        arguments: {
+          project_id: project.id,
+          name: branchName,
+          confirm_cost_id: confirm_cost_id_result.confirmation_id,
+        },
+      });
+
+      expect(result).toMatchObject({
+        name: branchName,
+        parent_project_ref: project.id,
+      });
+      // Creating a project's first branch also mints a same-named
+      // `is_default` mock branch representing the parent project itself -
+      // filter it out to count only the branch this call created.
+      expect(
+        Array.from(mockBranches.values()).filter(
+          (branch) => branch.name === branchName && !branch.is_default
+        )
+      ).toHaveLength(1);
+    });
+
+    test('form-capable client: accept creates the branch exactly once', async () => {
+      const { client } = await setupFormCapable({
+        elicitationAction: 'accept',
+      });
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const result = await client.callTool({
+        name: 'create_branch',
+        arguments: { project_id: project.id, name: 'test-branch' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const [content] = result.content;
+      if (content?.type !== 'text') {
+        throw new Error('expected text content');
+      }
+      const branch = JSON.parse(content.text);
+      expect(branch).toMatchObject({
+        name: 'test-branch',
+        parent_project_ref: project.id,
+      });
+      expect(
+        Array.from(mockBranches.values()).filter(
+          (branch) => branch.name === 'test-branch' && !branch.is_default
+        )
+      ).toHaveLength(1);
+    });
+
+    test('form-capable client: decline does not create a branch', async () => {
+      const { client } = await setupFormCapable({
+        elicitationAction: 'decline',
+      });
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const result = await client.callTool({
+        name: 'create_branch',
+        arguments: { project_id: project.id, name: 'test-branch' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toEqual({ status: 'declined' });
+      expect(mockBranches.size).toBe(0);
+    });
+
+    test('form-capable client: cancel does not create a branch', async () => {
+      const { client } = await setupFormCapable({
+        elicitationAction: 'cancel',
+      });
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const result = await client.callTool({
+        name: 'create_branch',
+        arguments: { project_id: project.id, name: 'test-branch' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(result.structuredContent).toEqual({ status: 'cancelled' });
+      expect(mockBranches.size).toBe(0);
+    });
+
+    test('form-capable client: a supplied confirm_cost_id cannot bypass the form', async () => {
+      const { client } = await setupFormCapable();
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      // The correct legacy hash - even a valid confirmation ID must not
+      // let a form-capable client skip straight to creation.
+      const legacyConfirmCostId = await hashObject(getBranchCost());
+
+      const result = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_branch',
+            arguments: {
+              project_id: project.id,
+              name: 'test-branch',
+              confirm_cost_id: legacyConfirmCostId,
+            },
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(result)) {
+        throw new Error('expected an input_required result');
+      }
+      expect(mockBranches.size).toBe(0);
+    });
+
+    test('rejects a retry whose arguments changed since the state was minted', async () => {
+      const { client } = await setupFormCapable();
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const first = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_branch',
+            arguments: { project_id: project.id, name: 'test-branch' },
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(first)) {
+        throw new Error('expected an input_required result');
+      }
+
+      const second = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_branch',
+            arguments: { project_id: project.id, name: 'renamed-branch' },
+            inputResponses: {
+              confirm_cost: { action: 'accept', content: {} },
+            },
+            requestState: first.requestState,
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (isInputRequiredResult(second)) {
+        throw new Error('expected a CallToolResult');
+      }
+
+      expect(second.isError).toBe(true);
+      expect(second.structuredContent).toEqual({ status: 'error' });
+      expect(mockBranches.size).toBe(0);
+    });
+
+    test('project-scoped server signs and uses the configured project', async () => {
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const { client } = await setupFormCapable({
+        projectId: project.id,
+        elicitationAction: 'accept',
+      });
+
+      const { tools } = await client.listTools();
+      const createBranchTool = tools.find(
+        (tool) => tool.name === 'create_branch'
+      );
+      expect(
+        Object.keys(createBranchTool?.inputSchema.properties ?? {})
+      ).not.toContain('project_id');
+
+      const result = await client.callTool({
+        name: 'create_branch',
+        arguments: { name: 'test-branch' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const [content] = result.content;
+      if (content?.type !== 'text') {
+        throw new Error('expected text content');
+      }
+      const branch = JSON.parse(content.text);
+      expect(branch).toMatchObject({
+        name: 'test-branch',
+        parent_project_ref: project.id,
+      });
+      expect(
+        Array.from(mockBranches.values()).filter(
+          (branch) => branch.name === 'test-branch' && !branch.is_default
+        )
+      ).toHaveLength(1);
+    });
   });
 
   test('delete branch', async () => {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -32,6 +32,7 @@ import {
 } from '../test/mocks.js';
 import { createSupabaseApiPlatform } from './platform/api-platform.js';
 import type { SupabasePlatform } from './platform/types.js';
+import * as pricing from './pricing.js';
 import {
   BRANCH_COST_HOURLY,
   getBranchCost,
@@ -3916,6 +3917,73 @@ describe('tools', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.structuredContent).toEqual({ status: 'cancelled' });
+      expect(mockBranches.size).toBe(0);
+    });
+
+    test('a decline is honored even when the quoted branch cost changed since the state was minted', async () => {
+      const getBranchCostSpy = vi
+        .spyOn(pricing, 'getBranchCost')
+        .mockReturnValueOnce({
+          type: 'branch',
+          recurrence: 'hourly',
+          amount: BRANCH_COST_HOURLY,
+        })
+        .mockReturnValueOnce({
+          type: 'branch',
+          recurrence: 'hourly',
+          amount: BRANCH_COST_HOURLY + 1,
+        });
+      const { client } = await setupFormCapable();
+
+      const org = await createOrganization({
+        name: 'My Org',
+        plan: 'free',
+        allowed_release_channels: ['ga'],
+      });
+      const project = await createProject({
+        name: 'Project 1',
+        region: 'us-east-1',
+        organization_id: org.id,
+      });
+      project.status = 'ACTIVE_HEALTHY';
+
+      const args = { project_id: project.id, name: 'test-branch' };
+      const first = (await client.request(
+        {
+          method: 'tools/call',
+          params: { name: 'create_branch', arguments: args },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      if (!isInputRequiredResult(first)) {
+        throw new Error('expected an input_required result');
+      }
+      expect(first.inputRequests.confirm_cost).toMatchObject({
+        mode: 'form',
+        message: expect.stringContaining(`$${BRANCH_COST_HOURLY}/hr`),
+      });
+
+      const second = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'create_branch',
+            arguments: args,
+            inputResponses: {
+              confirm_cost: { action: 'decline' },
+            },
+            requestState: first.requestState,
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+      getBranchCostSpy.mockRestore();
+
+      if (isInputRequiredResult(second)) {
+        throw new Error('expected a CallToolResult');
+      }
+      expect(second.structuredContent).toEqual({ status: 'declined' });
       expect(mockBranches.size).toBe(0);
     });
 

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4011,10 +4011,15 @@ describe('tools', () => {
           method: 'elicitation/create',
           params: {
             mode: 'form',
-            message: expect.stringMatching(
-              new RegExp(
-                `\\$${BRANCH_COST_HOURLY.toString().replace('.', '\\.')}/hr[\\s\\S]*standard, before plan allowances or exemptions; actual charges may be lower`
-              )
+            message: expect.stringContaining(`$${BRANCH_COST_HOURLY}/hr`),
+          },
+        });
+        expect(first.inputRequests?.confirm_cost).toMatchObject({
+          method: 'elicitation/create',
+          params: {
+            mode: 'form',
+            message: expect.stringContaining(
+              'standard, before plan allowances or exemptions; actual charges may be lower'
             ),
           },
         });

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4019,7 +4019,16 @@ describe('tools', () => {
           params: {
             mode: 'form',
             message: expect.stringContaining(
-              'standard, before plan allowances or exemptions; actual charges may be lower'
+              'Standard rate, before plan allowances or exemptions.'
+            ),
+          },
+        });
+        expect(first.inputRequests?.confirm_cost).toMatchObject({
+          method: 'elicitation/create',
+          params: {
+            mode: 'form',
+            message: expect.stringContaining(
+              'until deleted (~$9.68 per 30 days).'
             ),
           },
         });

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4011,7 +4011,11 @@ describe('tools', () => {
           method: 'elicitation/create',
           params: {
             mode: 'form',
-            message: expect.stringContaining(`$${BRANCH_COST_HOURLY}/hr`),
+            message: expect.stringMatching(
+              new RegExp(
+                `\\$${BRANCH_COST_HOURLY.toString().replace('.', '\\.')}/hr[\\s\\S]*standard, before plan allowances or exemptions; actual charges may be lower`
+              )
+            ),
           },
         });
 

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -60,8 +60,9 @@ export type SupabaseMcpServerOptions = {
   /**
    * Enables cost confirmation via elicitation for clients that declare
    * per-request form-elicitation capability. Clients without that
-   * capability keep using `get_cost` -> `confirm_cost` ->
-   * `create_project(confirm_cost_id)`.
+   * capability keep using `get_cost` -> `confirm_cost` -> the relevant
+   * project or branch `confirm_cost_id` flow (`create_project` or
+   * `create_branch`).
    */
   costConfirmation?: {
     /** HMAC key for the `requestState` codec. MUST be at least 32 bytes. */
@@ -71,7 +72,7 @@ export type SupabaseMcpServerOptions = {
     /** How long a minted `requestState` stays valid, in seconds. */
     ttlSeconds?: number;
     /** Tools that accept a cost-confirmation elicitation. */
-    enabledTools: readonly 'create_project'[];
+    enabledTools: readonly ('create_project' | 'create_branch')[];
   };
 };
 
@@ -135,9 +136,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     features ?? availableDefaultFeatures
   );
 
-  const costConfirmationCodec = costConfirmation?.enabledTools.includes(
-    'create_project'
-  )
+  const costConfirmationCodec = costConfirmation?.enabledTools.length
     ? createRequestStateCodec<CostConfirmationState>({
         key: costConfirmation.requestStateKey,
         ttlSeconds: costConfirmation.ttlSeconds,
@@ -191,9 +190,11 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
           getAccountTools({
             account,
             readOnly,
-            costConfirmation: costConfirmationCodec && {
-              codec: costConfirmationCodec,
-            },
+            costConfirmation:
+              costConfirmationCodec &&
+              costConfirmation?.enabledTools.includes('create_project')
+                ? { codec: costConfirmationCodec }
+                : undefined,
           })
         );
       }
@@ -227,7 +228,16 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       if (branching && enabledFeatures.has('branching')) {
         Object.assign(
           tools,
-          getBranchingTools({ branching, projectId, readOnly })
+          getBranchingTools({
+            branching,
+            projectId,
+            readOnly,
+            costConfirmation:
+              costConfirmationCodec &&
+              costConfirmation?.enabledTools.includes('create_branch')
+                ? { codec: costConfirmationCodec }
+                : undefined,
+          })
         );
       }
 

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -225,7 +225,7 @@ export function getBranchingTools({
                     `Hourly rate      $${cost.amount}${costSuffix}`,
                     `30-day estimate  ~$${(cost.amount * 24 * 30).toFixed(2)} if left running`,
                     '',
-                    'Assumes continuous running. Cost recurs until deletion.',
+                    'Rates and estimates shown are standard, before plan allowances or exemptions; actual charges may be lower. Assumes continuous running. Cost recurs until deletion.',
                   ].join('\n'),
                   requestedSchema: actionOnlyElicitationSchema,
                 }),

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -210,6 +210,7 @@ export function getBranchingTools({
         if (costConfirmation && isFormCapable(ctx)) {
           const { codec } = costConfirmation;
           const cost = getBranchCost();
+          const costSuffix = { hourly: '/hr' }[cost.recurrence];
 
           const askForConfirmation = async () =>
             inputRequired({
@@ -217,11 +218,11 @@ export function getBranchingTools({
                 confirm_cost: inputRequired.elicit({
                   mode: 'form',
                   message: [
-                    `Creating this branch costs $${cost.amount}/hr while it runs.`,
+                    `Creating this branch costs $${cost.amount}${costSuffix} while it runs.`,
                     '',
                     `Project          ${project_id}`,
                     `Branch           ${name}`,
-                    `Hourly rate      $${cost.amount}/hr`,
+                    `Hourly rate      $${cost.amount}${costSuffix}`,
                     `30-day estimate  ~$${(cost.amount * 24 * 30).toFixed(2)} if left running`,
                     '',
                     'Assumes continuous running. Cost recurs until deletion.',
@@ -266,17 +267,6 @@ export function getBranchingTools({
             };
           }
 
-          if (
-            state.cost.type !== cost.type ||
-            state.cost.recurrence !== cost.recurrence ||
-            state.cost.amount !== cost.amount
-          ) {
-            // Pricing changed since the state was minted - reissue a
-            // fresh prompt bound to the recomputed cost rather than
-            // honoring a stale quote.
-            return askForConfirmation();
-          }
-
           const response = inputResponse(
             ctx.mcpReq.inputResponses,
             'confirm_cost'
@@ -297,7 +287,7 @@ export function getBranchingTools({
             };
           }
 
-          if (response.action === 'cancel') {
+          if (response.action !== 'accept') {
             return {
               content: [
                 {
@@ -307,6 +297,17 @@ export function getBranchingTools({
               ],
               structuredContent: { status: 'cancelled' },
             };
+          }
+
+          if (
+            state.cost.type !== cost.type ||
+            state.cost.recurrence !== cost.recurrence ||
+            state.cost.amount !== cost.amount
+          ) {
+            // Pricing changed since the state was minted - reissue a
+            // fresh prompt bound to the recomputed cost rather than
+            // honoring a stale quote.
+            return askForConfirmation();
           }
 
           return await branching.createBranch(state.project_id, {

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -219,7 +219,7 @@ export function getBranchingTools({
                   mode: 'form',
                   message: [
                     `Preview branch: $${cost.amount}${costSuffix} until deleted (~$${(cost.amount * 24 * 30).toFixed(2)} per 30 days).`,
-                    'Auto-pauses on inactivity. https://supabase.com/docs/guides/deployment/branching#how-branching-works',
+                    'Auto-pauses on inactivity.',
                     'Standard rate, before plan allowances or exemptions.',
                   ].join('\n'),
                   requestedSchema: actionOnlyElicitationSchema,

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -218,14 +218,9 @@ export function getBranchingTools({
                 confirm_cost: inputRequired.elicit({
                   mode: 'form',
                   message: [
-                    `Creating this branch costs $${cost.amount}${costSuffix} while it runs.`,
-                    '',
-                    `Project          ${project_id}`,
-                    `Branch           ${name}`,
-                    `Hourly rate      $${cost.amount}${costSuffix}`,
-                    `30-day estimate  ~$${(cost.amount * 24 * 30).toFixed(2)} if left running`,
-                    '',
-                    'Rates and estimates shown are standard, before plan allowances or exemptions; actual charges may be lower. Assumes continuous running. Cost recurs until deletion.',
+                    `Preview branch: $${cost.amount}${costSuffix} until deleted (~$${(cost.amount * 24 * 30).toFixed(2)} per 30 days).`,
+                    'Auto-pauses on inactivity. https://supabase.com/docs/guides/deployment/branching#how-branching-works',
+                    'Standard rate, before plan allowances or exemptions.',
                   ].join('\n'),
                   requestedSchema: actionOnlyElicitationSchema,
                 }),

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -1,15 +1,35 @@
+import {
+  inputRequired,
+  inputResponse,
+  type RequestStateCodec,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
 import { tool } from '@supabase/mcp-utils';
 import { z } from 'zod/v4';
 import type { BranchingOperations } from '../platform/types.js';
 import { branchSchema } from '../platform/types.js';
 import { getBranchCost } from '../pricing.js';
 import { hashObject } from '../util.js';
+import {
+  actionOnlyElicitationSchema,
+  isFormCapable,
+  type CostConfirmationState,
+} from './cost-confirmation.js';
 import { injectableTool, type ToolDefs } from './util.js';
 
 type BranchingToolsOptions = {
   branching: BranchingOperations;
   projectId?: string;
   readOnly?: boolean;
+  /**
+   * Enables cost confirmation via elicitation inside `create_branch` for
+   * clients that declare per-request form capability (see
+   * `isFormCapable`). Absent, `create_branch` keeps requiring
+   * `confirm_cost_id` from `confirm_cost` unchanged.
+   */
+  costConfirmation?: {
+    codec: RequestStateCodec<CostConfirmationState>;
+  };
 };
 
 const createBranchInputSchema = z.object({
@@ -23,6 +43,15 @@ const createBranchInputSchema = z.object({
           : undefined,
     })
     .describe('The cost confirmation ID. Call `confirm_cost` first.'),
+});
+
+const createBranchInputSchemaWithElicitation = createBranchInputSchema.extend({
+  confirm_cost_id: z
+    .string()
+    .optional()
+    .describe(
+      'The cost confirmation ID. Only required for clients without per-request form-elicitation capability; those clients must call `confirm_cost` first. Form-capable clients are asked to confirm the cost inline when creating the branch.'
+    ),
 });
 
 const createBranchOutputSchema = branchSchema;
@@ -155,16 +184,134 @@ export function getBranchingTools({
   branching,
   projectId,
   readOnly,
+  costConfirmation,
 }: BranchingToolsOptions) {
   const project_id = projectId;
 
   return {
     create_branch: injectableTool({
       ...branchingToolDefs.create_branch,
+      parameters: costConfirmation
+        ? createBranchInputSchemaWithElicitation
+        : createBranchInputSchema,
       inject: { project_id },
-      execute: async ({ project_id, name, confirm_cost_id }) => {
+      execute: async (
+        {
+          project_id,
+          name,
+          confirm_cost_id,
+        }: z.infer<typeof createBranchInputSchemaWithElicitation>,
+        ctx: ServerContext
+      ) => {
         if (readOnly) {
           throw new Error('Cannot create a branch in read-only mode.');
+        }
+
+        if (costConfirmation && isFormCapable(ctx)) {
+          const { codec } = costConfirmation;
+          const cost = getBranchCost();
+
+          const askForConfirmation = async () =>
+            inputRequired({
+              inputRequests: {
+                confirm_cost: inputRequired.elicit({
+                  mode: 'form',
+                  message: [
+                    `Creating this branch costs $${cost.amount}/hr while it runs.`,
+                    '',
+                    `Project          ${project_id}`,
+                    `Branch           ${name}`,
+                    `Hourly rate      $${cost.amount}/hr`,
+                    `30-day estimate  ~$${(cost.amount * 24 * 30).toFixed(2)} if left running`,
+                    '',
+                    'Assumes continuous running. Cost recurs until deletion.',
+                  ].join('\n'),
+                  requestedSchema: actionOnlyElicitationSchema,
+                }),
+              },
+              requestState: await codec.mint(
+                { tool: 'create_branch', project_id, name, cost },
+                ctx
+              ),
+            });
+
+          const state = ctx.mcpReq.requestState<CostConfirmationState>();
+          if (!state) {
+            return askForConfirmation();
+          }
+
+          if (state.tool !== 'create_branch') {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Request state was not issued for create_branch.',
+                },
+              ],
+              structuredContent: { status: 'error' },
+              isError: true,
+            };
+          }
+
+          if (state.project_id !== project_id || state.name !== name) {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Request state arguments do not match the current arguments.',
+                },
+              ],
+              structuredContent: { status: 'error' },
+              isError: true,
+            };
+          }
+
+          if (
+            state.cost.type !== cost.type ||
+            state.cost.recurrence !== cost.recurrence ||
+            state.cost.amount !== cost.amount
+          ) {
+            // Pricing changed since the state was minted - reissue a
+            // fresh prompt bound to the recomputed cost rather than
+            // honoring a stale quote.
+            return askForConfirmation();
+          }
+
+          const response = inputResponse(
+            ctx.mcpReq.inputResponses,
+            'confirm_cost'
+          );
+          if (response.kind !== 'elicit') {
+            return askForConfirmation();
+          }
+
+          if (response.action === 'decline') {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Branch creation was declined.',
+                },
+              ],
+              structuredContent: { status: 'declined' },
+            };
+          }
+
+          if (response.action === 'cancel') {
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: 'Branch creation was cancelled.',
+                },
+              ],
+              structuredContent: { status: 'cancelled' },
+            };
+          }
+
+          return await branching.createBranch(state.project_id, {
+            name: state.name,
+          });
         }
 
         const cost = getBranchCost();

--- a/packages/mcp-server-supabase/src/tools/cost-confirmation.test.ts
+++ b/packages/mcp-server-supabase/src/tools/cost-confirmation.test.ts
@@ -1,0 +1,70 @@
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  PROTOCOL_VERSION_META_KEY,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
+import { describe, expect, test } from 'vitest';
+
+import { isFormCapable } from './cost-confirmation.js';
+
+// Minimal ServerContext stub: only the envelope slice isFormCapable reads.
+function makeCtx(envelope: Record<string, unknown>): ServerContext {
+  return {
+    mcpReq: { envelope },
+  } as unknown as ServerContext;
+}
+
+// A valid envelope that satisfies both meta-key checks.
+function validBase(): Record<string, unknown> {
+  return {
+    [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
+    [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } },
+  };
+}
+
+describe('isFormCapable', () => {
+  test.each([
+    {
+      label: 'no elicitation key in capabilities',
+      envelope: {
+        ...validBase(),
+        [CLIENT_CAPABILITIES_META_KEY]: {},
+      },
+      expected: false,
+    },
+    {
+      label: 'elicitation is an empty object (any mode accepted)',
+      envelope: {
+        ...validBase(),
+        [CLIENT_CAPABILITIES_META_KEY]: { elicitation: {} },
+      },
+      expected: true,
+    },
+    {
+      label: 'elicitation has url mode only',
+      envelope: {
+        ...validBase(),
+        [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { url: {} } },
+      },
+      expected: false,
+    },
+    {
+      label: 'elicitation has form mode',
+      envelope: {
+        ...validBase(),
+        [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } },
+      },
+      expected: true,
+    },
+    {
+      label: 'form capability present but protocol version meta key absent',
+      envelope: {
+        [CLIENT_CAPABILITIES_META_KEY]: { elicitation: { form: {} } },
+        // PROTOCOL_VERSION_META_KEY intentionally omitted
+      },
+      expected: false,
+    },
+  ])('$label -> $expected', ({ envelope, expected }) => {
+    expect(isFormCapable(makeCtx(envelope))).toBe(expected);
+  });
+});

--- a/packages/mcp-server-supabase/src/tools/cost-confirmation.ts
+++ b/packages/mcp-server-supabase/src/tools/cost-confirmation.ts
@@ -3,7 +3,7 @@ import {
   PROTOCOL_VERSION_META_KEY,
   type ServerContext,
 } from '@modelcontextprotocol/server';
-import type { Cost } from '../pricing.js';
+import type { BranchCost, Cost } from '../pricing.js';
 import type { AWS_REGION_CODES } from '../regions.js';
 
 /**
@@ -20,10 +20,22 @@ export type ProjectCostState = {
 };
 
 /**
+ * Signed `requestState` payload for the `create_branch` cost-confirmation
+ * elicitation, bound to the branch arguments and the cost quoted to the
+ * user.
+ */
+export type BranchCostState = {
+  tool: 'create_branch';
+  project_id: string;
+  name: string;
+  cost: BranchCost;
+};
+
+/**
  * Signed `requestState` payload for any cost-confirmation elicitation this
  * server issues, discriminated by `tool`.
  */
-export type CostConfirmationState = ProjectCostState;
+export type CostConfirmationState = ProjectCostState | BranchCostState;
 
 /**
  * An action-only elicitation: no properties, so the client renders the


### PR DESCRIPTION
Stacked on [#391](https://github.com/supabase/mcp/pull/391). Review that first. This is part of [AI-1091](https://linear.app/supabase/issue/AI-1091/ship-form-mode-cost-confirmation-stage-a-supabasemcp).

## What kind of change does this PR introduce?

Feature: add form-mode cost confirmation to `create_branch`.

## What is the current behavior?

#391 provides the shared confirmation codec/verifier, `ServerContext`, result passthrough, and project flow. Branch creation still uses the existing hash validation.

## What is the new behavior?

Modern form clients can call `create_branch` without `confirm_cost_id`. They receive an action-only, property-less prompt for **$0.01344/hr** (about **$9.68 over 30 days**).

Acceptance creates the branch from signed arguments. Missing responses and changed costs re-prompt. A wrong-tool state or changed arguments fail. Decline and cancel create no branch.

Capability-free and URL-only clients keep hash validation. A supplied legacy ID cannot bypass the capable-client flow. Project-scoped injection works, and existing output fields such as `with_data` remain.

## How to Review

1. **Server and shared state**
   - `packages/mcp-server-supabase/src/server.ts`
   - `packages/mcp-server-supabase/src/tools/cost-confirmation.ts`

2. **Branch handler and pricing**
   - `packages/mcp-server-supabase/src/tools/branching-tools.ts`
   - `packages/mcp-server-supabase/src/pricing.ts`

3. **Behavioral coverage**
   - `packages/mcp-server-supabase/src/server.test.ts`
   - Inspect the capable, legacy, argument-binding, and project-scoped paths.

- [ ] Is `create_branch` enabled only through the intended server path?
- [ ] Does the discriminated state bind project ID, branch name, and `BranchCost`?
- [ ] Do capable clients always use elicitation, even with a legacy ID?
- [ ] Do accept, decline, cancellation, wrong-tool, and argument-change outcomes look correct?

## Verification

- `pnpm --filter @supabase/mcp-server-supabase test src/server.test.ts -t "create_(project|branch) cost confirmation via elicitation"` (17 passed)
- `pnpm --filter @supabase/mcp-server-supabase build` (typecheck + build passed)
- `pnpm test:packed-platform-consumer` (3 assertions passed)
- `pnpm exec biome ci .` (passed)

## Additional context

Commit `24535f1 chore: refresh management API types` adds two generated lines to `packages/mcp-server-supabase/src/management-api/types.ts` because the CI generation gate detected upstream schema drift. Feature behavior and verification remain unchanged.

This does not change `create_project`, `mcp-utils`, platform adapters, stdio, pricing values, manifests, or docs.

Known limits: confirmations are not single-use, legacy IDs remain precomputable, and the branch rate remains the existing package constant.

AI-assisted; human review required.
