### PR TITLE
docs(list_tables): clarify schemas default and [] for all schemas

### DIFF
--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -27,7 +27,9 @@ const listTablesInputSchema = z.object({
   project_id: z.string(),
   schemas: z
     .array(z.string())
-    .describe('List of schemas to include. Defaults to all schemas.')
+    .describe(
+      'List of schemas to include. Defaults to ["public"]. Pass [] to include all non-system schemas.'
+    )
     .default(['public']),
   verbose: z
     .boolean()


### PR DESCRIPTION
Fixes #395

## Problem

In listTablesInputSchema, the schemas parameter description stated:
> `List of schemas to include. Defaults to all schemas.`

However, the field is configured with .default(['public']), so omitting schemas actually queries only the public schema. Furthermore, passing an empty array [] is the mechanism that generates a where schema not in (SYSTEM_SCHEMAS) query to include all non-system schemas.

## Fix

Updated the parameter description to accurately reflect the default value and how to request all schemas:
> `List of schemas to include. Defaults to [public]. Pass [] to include all non-system schemas.`