### PR TITLE
fix(mcp-server-supabase): clarify list_tables schemas parameter description and default behavior

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -1050,6 +1050,75 @@ describe('tools', () => {
     });
   });
 
+  test('list_tables with empty schemas [] includes tables across all non-system schemas', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    await project.db.exec(`
+      create schema custom_schema;
+      create table test_public (id integer generated always as identity primary key);
+      create table custom_schema.test_custom (id integer generated always as identity primary key);
+    `);
+
+    const result = await callTool({
+      name: 'list_tables',
+      arguments: {
+        project_id: project.id,
+        schemas: [],
+      },
+    });
+
+    const tableNames = result.tables.map((t: { name: string }) => t.name);
+    expect(tableNames).toContain('public.test_public');
+    expect(tableNames).toContain('custom_schema.test_custom');
+  });
+
+  test('list_tables omitting schemas defaults to public schema', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    await project.db.exec(`
+      create schema custom_schema;
+      create table test_public (id integer generated always as identity primary key);
+      create table custom_schema.test_custom (id integer generated always as identity primary key);
+    `);
+
+    const result = await callTool({
+      name: 'list_tables',
+      arguments: {
+        project_id: project.id,
+      },
+    });
+
+    const tableNames = result.tables.map((t: { name: string }) => t.name);
+    expect(tableNames).toContain('public.test_public');
+    expect(tableNames).not.toContain('custom_schema.test_custom');
+  });
+
   test('list_tables returns full details when verbose is true', async () => {
     const { callTool } = await setup();
 

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -27,7 +27,9 @@ const listTablesInputSchema = z.object({
   project_id: z.string(),
   schemas: z
     .array(z.string())
-    .describe('List of schemas to include. Defaults to all schemas.')
+    .describe(
+      'List of schemas to include. Defaults to ["public"]. Pass [] to include all non-system schemas.'
+    )
     .default(['public']),
   verbose: z
     .boolean()


### PR DESCRIPTION
## Summary
Fixes #395. Clarifies the `schemas` parameter description for the `list_tables` tool in `@supabase/mcp-server-supabase`.

The schema parameter description previously stated `"Defaults to all schemas."` while the Zod schema defaulted to `['public']`. This caused confusion when callers expected all user schemas to be evaluated in database-wide RLS security advisories.

This change:
1. Clarifies the description: `'List of schemas to include. Defaults to ["public"]. Pass [] to include all non-system schemas.'`
2. Adds regression unit tests in `src/server.test.ts` verifying that omitting `schemas` defaults to `public`, while passing `schemas: []` queries all non-system user schemas across schemas.

## Validation
- `vitest run -t "list_tables" src/server.test.ts` (7/7 passed)
- `vitest run src/tools/tool-schemas.test.ts` (19/19 passed)
