### PR TITLE
feat(mcp): add --http flag to serve the package over HTTP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Configure your MCP client to run the local build. You may need to restart the se
     "supabase": {
       "command": "node",
       "args": [
-        "/path/to/supabase-mcp/packages/mcp-server-supabase/dist/transports/stdio.js",
+        "/path/to/supabase-mcp/packages/mcp-server-supabase/dist/cli.js",
         "--project-ref",
         "<your project ref>"
       ],

--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ const tools = await mcpClient.tools({
 
 For more information, see [Schema Definition](https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools#schema-definition) and [Typed Tool Outputs](https://ai-sdk.dev/docs/ai-sdk-core/mcp-tools#typed-tool-outputs) in the AI SDK docs.
 
+## Local HTTP dev server
+
+Pass `--http` to serve the current build over HTTP on `http://localhost:3100/mcp` (override with `--port`) instead of stdio. It behaves like the hosted endpoint: the PAT goes in an `Authorization: Bearer` header and `project_ref`, `read_only`, and `features` are query params, so the same client config works against both. Use it to test a build (including a `pkg.pr.new` preview) from any HTTP MCP client without running platform.
+
+Unlike the exported handler it also serves 2025-era clients statelessly, so VS Code works too. Claude Code needs `MCP_SDK_GENERATION=v2 MCP_PROTOCOL_NEGOTIATION=auto` to negotiate the current revision.
+
+```bash
+npx @supabase/mcp-server-supabase --http --api-url=https://api.supabase.green
+```
+
+```json
+{
+  "mcpServers": {
+    "supabase-local": {
+      "type": "http",
+      "url": "http://localhost:3100/mcp?project_ref=<project-ref>",
+      "headers": {
+        "Authorization": "Bearer <personal-access-token>"
+      }
+    }
+  }
+}
+```
+
 ## Self-hosting the MCP endpoint
 
 The `@supabase/mcp-server-supabase` package exports `createSupabaseMcpHandler()` to serve the tools over HTTP from your own endpoint. It accepts the same `SupabaseMcpServerOptions` as `createSupabaseMcpServer()`, most importantly `platform`.

--- a/README.md
+++ b/README.md
@@ -112,12 +112,10 @@ For more information, see [Schema Definition](https://ai-sdk.dev/docs/ai-sdk-cor
 
 ## Local HTTP dev server
 
-Pass `--http` to serve the current build over HTTP on `http://localhost:3100/mcp` (override with `--port`) instead of stdio. It behaves like the hosted endpoint: the PAT goes in an `Authorization: Bearer` header and `project_ref`, `read_only`, and `features` are query params, so the same client config works against both. Use it to test a build (including a `pkg.pr.new` preview) from any HTTP MCP client without running platform.
-
-Unlike the exported handler it also serves 2025-era clients statelessly, so VS Code works too. Claude Code needs `MCP_SDK_GENERATION=v2 MCP_PROTOCOL_NEGOTIATION=auto` to negotiate the current revision.
+Pass `--http` to serve the package over HTTP instead of stdio. It listens on `http://localhost:3100/mcp` and takes the same inputs as the hosted endpoint. The PAT goes in an `Authorization: Bearer` header, and `project_ref`, `read_only`, and `features` are query params. Use `--port` to change the port.
 
 ```bash
-npx @supabase/mcp-server-supabase --http --api-url=https://api.supabase.green
+npx @supabase/mcp-server-supabase --http
 ```
 
 ```json

--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -32,7 +32,7 @@
     "dist/**/*"
   ],
   "bin": {
-    "mcp-server-supabase": "./dist/transports/stdio.js"
+    "mcp-server-supabase": "./dist/cli.js"
   },
   "exports": {
     ".": {

--- a/packages/mcp-server-supabase/src/cli.ts
+++ b/packages/mcp-server-supabase/src/cli.ts
@@ -2,11 +2,12 @@
 import { parseArgs } from 'node:util';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
 
-import packageJson from '../../package.json' with { type: 'json' };
-import { createSupabaseApiPlatform } from '../platform/api-platform.js';
-import { createSupabaseMcpServer } from '../server.js';
-import { parseFeatureGroups } from '../util.js';
-import { parseList } from './util.js';
+import packageJson from '../package.json' with { type: 'json' };
+import { createSupabaseApiPlatform } from './platform/api-platform.js';
+import { createSupabaseMcpServer } from './server.js';
+import { serveHttp } from './transports/http.js';
+import { parseList } from './transports/util.js';
+import { parseFeatureGroups } from './util.js';
 
 const { version } = packageJson;
 
@@ -20,6 +21,8 @@ async function main() {
       ['content-api-url']: cliContentApiUrl,
       ['version']: showVersion,
       ['features']: cliFeatures,
+      ['http']: http,
+      ['port']: cliPort,
     },
   } = parseArgs({
     options: {
@@ -45,12 +48,30 @@ async function main() {
       ['features']: {
         type: 'string',
       },
+      ['http']: {
+        type: 'boolean',
+        default: false,
+      },
+      ['port']: {
+        type: 'string',
+        default: '3100',
+      },
     },
   });
 
   if (showVersion) {
     console.log(version);
     process.exit(0);
+  }
+
+  const contentApiUrl =
+    cliContentApiUrl ?? process.env.SUPABASE_CONTENT_API_URL;
+
+  if (http) {
+    // Mirrors the hosted endpoint: the PAT comes from the `Authorization`
+    // header and scoping from query params, so the flags below don't apply.
+    serveHttp({ port: Number(cliPort), apiUrl, contentApiUrl });
+    return;
   }
 
   const accessToken = cliAccessToken ?? process.env.SUPABASE_ACCESS_TOKEN;
@@ -64,9 +85,6 @@ async function main() {
 
   const features = cliFeatures ? parseList(cliFeatures) : undefined;
 
-  const contentApiUrl =
-    cliContentApiUrl ?? process.env.SUPABASE_CONTENT_API_URL;
-
   const platform = createSupabaseApiPlatform({
     accessToken,
     apiUrl,
@@ -76,20 +94,20 @@ async function main() {
     parseFeatureGroups(platform, features);
   }
 
+  const options = {
+    platform,
+    projectId,
+    readOnly,
+    features,
+    contentApiUrl,
+  };
+
   // `serveStdio` reports transport startup and out-of-band wire errors only
   // through `onerror`, and swallows them otherwise, so this keeps the stderr
   // output the previous awaited `server.connect()` got from `main().catch`.
-  serveStdio(
-    () =>
-      createSupabaseMcpServer({
-        platform,
-        projectId,
-        readOnly,
-        features,
-        contentApiUrl,
-      }),
-    { onerror: console.error }
-  );
+  serveStdio(() => createSupabaseMcpServer(options), {
+    onerror: console.error,
+  });
 }
 
 main().catch(console.error);

--- a/packages/mcp-server-supabase/src/cli.ts
+++ b/packages/mcp-server-supabase/src/cli.ts
@@ -68,8 +68,8 @@ async function main() {
     cliContentApiUrl ?? process.env.SUPABASE_CONTENT_API_URL;
 
   if (http) {
-    // Mirrors the hosted endpoint: the PAT comes from the `Authorization`
-    // header and scoping from query params, so the flags below don't apply.
+    // HTTP mode takes the PAT and scoping per request like the hosted
+    // endpoint, so the flags below don't apply.
     serveHttp({ port: Number(cliPort), apiUrl, contentApiUrl });
     return;
   }

--- a/packages/mcp-server-supabase/src/transports/http.ts
+++ b/packages/mcp-server-supabase/src/transports/http.ts
@@ -33,11 +33,7 @@ export type ServeHttpOptions = {
   contentApiUrl?: string;
 };
 
-/**
- * Local dev server shaped like the hosted endpoint. Bearer PAT in the
- * `Authorization` header, `project_ref`, `read_only`, and `features` as
- * query params, both protocol eras. Bodies are buffered.
- */
+/** Local dev server shaped like the hosted endpoint. Bodies are buffered. */
 export function serveHttp({ port, apiUrl, contentApiUrl }: ServeHttpOptions) {
   createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', `http://localhost:${port}`);
@@ -68,10 +64,10 @@ export function serveHttp({ port, apiUrl, contentApiUrl }: ServeHttpOptions) {
       features: query.data.features,
       contentApiUrl,
     };
-    // Also serve 2025-era clients statelessly, like the hosted legacy leg.
-    const handler = createMcpHandler(() => createSupabaseMcpServer(options), {
-      legacy: 'stateless',
-    });
+    // Uses the SDK default `legacy: 'stateless'` so 2025-era clients are
+    // served too, unlike `createSupabaseMcpHandler` above.
+    // https://github.com/modelcontextprotocol/typescript-sdk/blob/cc4b41617ce3601b1290d67216ea0b194a3cd9ac/packages/server/src/server/createMcpHandler.ts#L146-L157
+    const handler = createMcpHandler(() => createSupabaseMcpServer(options));
     res.on('close', () => {
       handler.close().catch(console.error);
     });

--- a/packages/mcp-server-supabase/src/transports/http.ts
+++ b/packages/mcp-server-supabase/src/transports/http.ts
@@ -23,9 +23,9 @@ export type ServeHttpOptions = {
 };
 
 /**
- * Local dev server that mirrors the hosted endpoint: a `Bearer` PAT in the
- * `Authorization` header, `project_ref`, `read_only`, and `features` query
- * params, and both protocol eras. Bodies are buffered rather than streamed.
+ * Local dev server shaped like the hosted endpoint. Bearer PAT in the
+ * `Authorization` header, `project_ref`, `read_only`, and `features` as
+ * query params, both protocol eras. Bodies are buffered.
  */
 export function serveHttp({ port, apiUrl, contentApiUrl }: ServeHttpOptions) {
   createServer(async (req, res) => {
@@ -51,8 +51,7 @@ export function serveHttp({ port, apiUrl, contentApiUrl }: ServeHttpOptions) {
       features: features ? parseList(features) : undefined,
       contentApiUrl,
     };
-    // Unlike the exported handler, also serve 2025-era clients (VS Code at
-    // the time of writing) statelessly, like the hosted legacy leg does.
+    // Also serve 2025-era clients statelessly, like the hosted legacy leg.
     const handler = createMcpHandler(() => createSupabaseMcpServer(options), {
       legacy: 'stateless',
     });

--- a/packages/mcp-server-supabase/src/transports/http.ts
+++ b/packages/mcp-server-supabase/src/transports/http.ts
@@ -1,5 +1,6 @@
 import { createServer } from 'node:http';
 import { createMcpHandler } from '@modelcontextprotocol/server';
+import { z } from 'zod/v4';
 
 import { createSupabaseApiPlatform } from '../platform/api-platform.js';
 import {
@@ -15,6 +16,16 @@ export function createSupabaseMcpHandler(options: SupabaseMcpServerOptions) {
     legacy: 'reject',
   });
 }
+
+// Same query params as the hosted endpoint.
+const querySchema = z.object({
+  project_ref: z.string().optional(),
+  read_only: z.stringbool().default(false),
+  features: z
+    .string()
+    .transform((value) => parseList(value))
+    .optional(),
+});
 
 export type ServeHttpOptions = {
   port: number;
@@ -43,12 +54,18 @@ export function serveHttp({ port, apiUrl, contentApiUrl }: ServeHttpOptions) {
       return;
     }
 
-    const features = url.searchParams.get('features');
+    const query = querySchema.safeParse(Object.fromEntries(url.searchParams));
+    if (!query.success) {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: z.prettifyError(query.error) }));
+      return;
+    }
+
     const options: SupabaseMcpServerOptions = {
       platform: createSupabaseApiPlatform({ accessToken, apiUrl }),
-      projectId: url.searchParams.get('project_ref') ?? undefined,
-      readOnly: url.searchParams.get('read_only') === 'true',
-      features: features ? parseList(features) : undefined,
+      projectId: query.data.project_ref,
+      readOnly: query.data.read_only,
+      features: query.data.features,
       contentApiUrl,
     };
     // Also serve 2025-era clients statelessly, like the hosted legacy leg.

--- a/packages/mcp-server-supabase/src/transports/http.ts
+++ b/packages/mcp-server-supabase/src/transports/http.ts
@@ -1,14 +1,83 @@
+import { createServer } from 'node:http';
 import { createMcpHandler } from '@modelcontextprotocol/server';
 
+import { createSupabaseApiPlatform } from '../platform/api-platform.js';
 import {
   createSupabaseMcpServer,
   type SupabaseMcpServerOptions,
 } from '../server.js';
+import { parseList } from './util.js';
 
 // Modern protocol only: created with `legacy: 'reject'`, so a client that
 // speaks just the 2025-era protocol gets an HTTP 400 instead of being served.
 export function createSupabaseMcpHandler(options: SupabaseMcpServerOptions) {
   return createMcpHandler(() => createSupabaseMcpServer(options), {
     legacy: 'reject',
+  });
+}
+
+export type ServeHttpOptions = {
+  port: number;
+  apiUrl?: string;
+  contentApiUrl?: string;
+};
+
+/**
+ * Local dev server that mirrors the hosted endpoint: a `Bearer` PAT in the
+ * `Authorization` header, `project_ref`, `read_only`, and `features` query
+ * params, and both protocol eras. Bodies are buffered rather than streamed.
+ */
+export function serveHttp({ port, apiUrl, contentApiUrl }: ServeHttpOptions) {
+  createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`);
+    const accessToken = req.headers.authorization?.match(/^Bearer (.+)$/i)?.[1];
+
+    if (!accessToken) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          error:
+            'Missing `Authorization: Bearer <personal access token>` header',
+        })
+      );
+      return;
+    }
+
+    const features = url.searchParams.get('features');
+    const options: SupabaseMcpServerOptions = {
+      platform: createSupabaseApiPlatform({ accessToken, apiUrl }),
+      projectId: url.searchParams.get('project_ref') ?? undefined,
+      readOnly: url.searchParams.get('read_only') === 'true',
+      features: features ? parseList(features) : undefined,
+      contentApiUrl,
+    };
+    // Unlike the exported handler, also serve 2025-era clients (VS Code at
+    // the time of writing) statelessly, like the hosted legacy leg does.
+    const handler = createMcpHandler(() => createSupabaseMcpServer(options), {
+      legacy: 'stateless',
+    });
+    res.on('close', () => {
+      handler.close().catch(console.error);
+    });
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const body = chunks.length > 0 ? Buffer.concat(chunks) : undefined;
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+      for (const v of Array.isArray(value) ? value : [value]) {
+        if (v !== undefined) headers.append(key, v);
+      }
+    }
+
+    const response = await handler.fetch(
+      new Request(url, { method: req.method, headers, body })
+    );
+
+    res.writeHead(response.status, Object.fromEntries(response.headers));
+    res.end(Buffer.from(await response.arrayBuffer()));
+  }).listen(port, () => {
+    console.error(`Supabase MCP server on http://localhost:${port}/mcp`);
   });
 }

--- a/packages/mcp-server-supabase/test/stdio.integration.ts
+++ b/packages/mcp-server-supabase/test/stdio.integration.ts
@@ -27,7 +27,7 @@ type SetupOptions = {
 };
 
 function assertStdioBuildIsFresh() {
-  const buildPath = 'dist/transports/stdio.js';
+  const buildPath = 'dist/cli.js';
   const newestSource = readdirSync('src', {
     recursive: true,
     withFileTypes: true,
@@ -86,7 +86,7 @@ async function setup(options: SetupOptions = {}) {
   });
 
   const command = 'node';
-  const args = ['dist/transports/stdio.js'];
+  const args = ['dist/cli.js'];
 
   if (accessToken) {
     args.push('--access-token', accessToken);

--- a/packages/mcp-server-supabase/tsup.config.ts
+++ b/packages/mcp-server-supabase/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig([
   {
     entry: [
       'src/index.ts',
-      'src/transports/stdio.ts',
+      'src/cli.ts',
       'src/platform/index.ts',
       'src/platform/api-platform.ts',
     ],

--- a/packages/mcp-server-supabase/vitest.config.ts
+++ b/packages/mcp-server-supabase/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'lcov'],
       include: ['src/**/*.{ts,tsx}'],
-      exclude: [...configDefaults.coverage.exclude!, 'src/transports/stdio.ts'],
+      exclude: [...configDefaults.coverage.exclude!, 'src/cli.ts'],
     },
   },
 });


### PR DESCRIPTION
Adds an `--http` flag to the existing bin so you can test the package over HTTP without running platform locally, with similar inputs as the hosted endpoint.

Opening as a draft mostly as a smaller reference point next to #401.

To run preview:

```bash
npx https://pkg.pr.new/@supabase/mcp-server-supabase@402 --http
```

Client config:

```json
{
  "mcpServers": {
    "supabase-local": {
      "type": "http",
      "url": "http://localhost:3100/mcp?project_ref=<ref>",
      "headers": { "Authorization": "Bearer <pat>" }
    }
  }
}
```

Closes AI-1166

