### PR TITLE
feat(advisors): add health advisor support

### DIFF
--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -4,6 +4,7 @@ import {
 } from '@mjackson/multipart-parser';
 import type { InitData } from '@supabase/mcp-utils';
 import { fileURLToPath } from 'node:url';
+import { z } from 'zod/v4';
 import packageJson from '../../package.json' with { type: 'json' };
 import { getDeploymentId, normalizeFilename } from '../edge-function.js';
 import { getClickHouseLogQuery } from '../logs.js';
@@ -48,6 +49,32 @@ const { version } = packageJson;
 
 const SUCCESS_RESPONSE: SuccessResponse = { success: true };
 
+const healthAdvisorLintNames = [
+  'instance_db_down',
+  'db_not_reachable',
+  'db_connection_limit_reached',
+  'log_data_api_error_rate_high',
+  'log_auth_error_rate_high',
+  'log_storage_error_rate_high',
+  'log_edge_function_error_rate_high',
+  'instance_alert_firing',
+] as const;
+
+const healthAdvisorResultOnlyLintNames = new Set([
+  'project_not_active',
+  'advisor_check_unavailable',
+]);
+
+const healthAdvisorResponseSchema = z.object({
+  data: z.object({
+    attributes: z.object({
+      lints: z.array(z.object({ name: z.string().optional() }).passthrough()),
+    }),
+  }),
+});
+
+const errorMessageSchema = z.object({ message: z.string() });
+
 export type SupabaseApiPlatformOptions = {
   /**
    * The access token for the Supabase Management API.
@@ -69,6 +96,9 @@ export function createSupabaseApiPlatform(
   const { accessToken, apiUrl } = options;
 
   const managementApiUrl = apiUrl ?? 'https://api.supabase.com';
+  let managementApiHeaders: Record<string, string> = {
+    Authorization: `Bearer ${accessToken}`,
+  };
 
   let managementApiClient = createManagementApiClient(
     managementApiUrl,
@@ -308,6 +338,62 @@ export function createSupabaseApiPlatform(
       assertSuccess(response, 'Failed to fetch performance advisors');
 
       return response.data;
+    },
+    async getHealthAdvisors(projectId: string) {
+      const response = await fetch(
+        new URL(
+          `/v2/projects/${encodeURIComponent(projectId)}/advisors/run`,
+          managementApiUrl
+        ),
+        {
+          method: 'POST',
+          headers: {
+            ...managementApiHeaders,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            data: {
+              type: 'project_advisors',
+              attributes: {
+                lints: healthAdvisorLintNames.map((name) => ({ name })),
+              },
+            },
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error(
+            'Unauthorized. Please provide a valid access token to the MCP server via the --access-token flag or SUPABASE_ACCESS_TOKEN.'
+          );
+        }
+
+        const error = errorMessageSchema.safeParse(
+          await response.json().catch(() => undefined)
+        );
+
+        if (error.success) {
+          throw new Error(error.data.message);
+        }
+
+        throw new Error('Failed to fetch health advisors');
+      }
+
+      const result = healthAdvisorResponseSchema.safeParse(
+        await response.json().catch(() => undefined)
+      );
+
+      if (!result.success) {
+        throw new Error('Failed to fetch health advisors');
+      }
+
+      return {
+        lints: result.data.data.attributes.lints.filter(
+          (lint) =>
+            !lint.name || !healthAdvisorResultOnlyLintNames.has(lint.name)
+        ),
+      };
     },
   };
 
@@ -795,12 +881,16 @@ export function createSupabaseApiPlatform(
         throw new Error('Client info is required');
       }
 
-      // Re-initialize the management API client with the user agent
+      const userAgent = `supabase-mcp/${version} (${clientInfo.name}/${clientInfo.version})`;
+      managementApiHeaders = {
+        Authorization: `Bearer ${accessToken}`,
+        'User-Agent': userAgent,
+      };
       managementApiClient = createManagementApiClient(
         managementApiUrl,
         accessToken,
         {
-          'User-Agent': `supabase-mcp/${version} (${clientInfo.name}/${clientInfo.version})`,
+          'User-Agent': userAgent,
         }
       );
     },

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -214,6 +214,7 @@ export type DebuggingOperations = {
   getLogs(projectId: string, options: GetLogsOptions): Promise<unknown>;
   getSecurityAdvisors(projectId: string): Promise<unknown>;
   getPerformanceAdvisors(projectId: string): Promise<unknown>;
+  getHealthAdvisors(projectId: string): Promise<unknown>;
 };
 
 export const apiKeyTypeSchema = z.enum(['legacy', 'publishable']);

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -19,6 +19,8 @@ import {
   createProject,
   MCP_CLIENT_NAME,
   MCP_CLIENT_VERSION,
+  MCP_SERVER_NAME,
+  MCP_SERVER_VERSION,
   mockBranches,
   mockContentApi,
   mockContentApiSchemaLoadCount,
@@ -2124,6 +2126,139 @@ describe('tools', () => {
     });
 
     expect(result).toEqual({ lints: [] });
+  });
+
+  test('get health advisors', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    mockServer?.use(
+      http.post(
+        `${API_URL}/v2/projects/:projectId/advisors/run`,
+        async ({ request }) => {
+          expect(request.headers.get('user-agent')).toBe(
+            `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION} (${MCP_CLIENT_NAME}/${MCP_CLIENT_VERSION})`
+          );
+          expect(await request.json()).toEqual({
+            data: {
+              type: 'project_advisors',
+              attributes: {
+                lints: [
+                  { name: 'instance_db_down' },
+                  { name: 'db_not_reachable' },
+                  { name: 'db_connection_limit_reached' },
+                  { name: 'log_data_api_error_rate_high' },
+                  { name: 'log_auth_error_rate_high' },
+                  { name: 'log_storage_error_rate_high' },
+                  { name: 'log_edge_function_error_rate_high' },
+                  { name: 'instance_alert_firing' },
+                ],
+              },
+            },
+          });
+
+          return HttpResponse.json({
+            data: {
+              type: 'project_advisors',
+              attributes: {
+                lints: [
+                  { name: 'instance_db_down', level: 'WARN' },
+                  { name: 'project_not_active', level: 'INFO' },
+                  { name: 'advisor_check_unavailable', level: 'INFO' },
+                ],
+              },
+            },
+          });
+        }
+      )
+    );
+
+    const { result } = await callTool({
+      name: 'get_advisors',
+      arguments: {
+        project_id: project.id,
+        type: 'health',
+      },
+    });
+
+    expect(result).toEqual({
+      lints: [{ name: 'instance_db_down', level: 'WARN' }],
+    });
+  });
+
+  test('encodes project IDs for health advisors', async () => {
+    const platform = createSupabaseApiPlatform({
+      accessToken: ACCESS_TOKEN,
+      apiUrl: API_URL,
+    });
+    const projectId = 'project/ref with spaces';
+    let requestUrl: string | undefined;
+
+    mockServer?.use(
+      http.post(
+        `${API_URL}/v2/projects/:projectId/advisors/run`,
+        ({ request }) => {
+          requestUrl = request.url;
+
+          return HttpResponse.json({
+            data: {
+              type: 'project_advisors',
+              attributes: { lints: [] },
+            },
+          });
+        }
+      )
+    );
+
+    await platform.debugging?.getHealthAdvisors(projectId);
+
+    expect(requestUrl).toBe(
+      `${API_URL}/v2/projects/project%2Fref%20with%20spaces/advisors/run`
+    );
+  });
+
+  test('rejects malformed health advisor responses', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+
+    mockServer?.use(
+      http.post(`${API_URL}/v2/projects/:projectId/advisors/run`, () =>
+        HttpResponse.json({ data: { attributes: { lints: null } } })
+      )
+    );
+
+    await expect(
+      callTool({
+        name: 'get_advisors',
+        arguments: {
+          project_id: project.id,
+          type: 'health',
+        },
+      })
+    ).rejects.toThrow('Failed to fetch health advisors');
   });
 
   test('get logs for invalid service type', async () => {

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -38,7 +38,7 @@ const getLogsOutputSchema = z.object({
 const getAdvisorsInputSchema = z.object({
   project_id: z.string(),
   type: z
-    .enum(['security', 'performance'])
+    .enum(['security', 'performance', 'health'])
     .describe('The type of advisors to fetch'),
 });
 
@@ -62,7 +62,7 @@ export const debuggingToolDefs = {
   },
   get_advisors: {
     description:
-      "Gets a list of advisory notices for the Supabase project. Use this to check for security vulnerabilities or performance improvements. Include the remediation URL as a clickable link so that the user can reference the issue themselves. It's recommended to run this tool regularly, especially after making DDL changes to the database since it will catch things like missing RLS policies.",
+      "Gets a list of advisory notices for the Supabase project. Use this to check for security vulnerabilities, performance improvements, or health issues. Include the remediation URL as a clickable link so that the user can reference the issue themselves. It's recommended to run this tool regularly, especially after making DDL changes to the database since it will catch things like missing RLS policies.",
     parameters: getAdvisorsInputSchema,
     outputSchema: getAdvisorsOutputSchema,
     annotations: {
@@ -116,6 +116,9 @@ export function getDebuggingTools({
             break;
           case 'performance':
             result = await debugging.getPerformanceAdvisors(project_id);
+            break;
+          case 'health':
+            result = await debugging.getHealthAdvisors(project_id);
             break;
           default:
             throw new Error(`Unknown advisor type: ${type}`);

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -611,6 +611,28 @@ export const mockManagementApi = [
     }
   ),
 
+  http.post<{ projectId: string }>(
+    `${API_URL}/v2/projects/:projectId/advisors/run`,
+    async ({ params }) => {
+      const project = mockProjects.get(params.projectId);
+      if (!project) {
+        return HttpResponse.json(
+          { message: 'Project not found' },
+          { status: 404 }
+        );
+      }
+
+      return HttpResponse.json({
+        data: {
+          type: 'project_advisors',
+          attributes: {
+            lints: [],
+          },
+        },
+      });
+    }
+  ),
+
   /**
    * Create a new branch for a project
    */


### PR DESCRIPTION
## Problem

The MCP exposes Security and Performance Advisor findings, but it cannot retrieve the newer Health Advisor findings.

## Fix

Add `health` to the existing `get_advisors` tool. It runs the v2 Health Advisor checks, returns the established lint shape, and filters dashboard-only sentinel results.

## How to test

- Run `CI=1 pnpm --filter @supabase/mcp-server-supabase test -- --run src/server.test.ts`
- Expected result: 113 tests pass, including the Health Advisor payload, response normalization, project-ref encoding, and malformed-response cases.
- Run `pnpm --filter @supabase/mcp-server-supabase typecheck`
- Expected result: TypeScript completes without errors.