### PR TITLE
fix: ensure correct escaping in advisor

### DIFF
--- a/packages/mcp-server-supabase/src/advisories/advisories.test.ts
+++ b/packages/mcp-server-supabase/src/advisories/advisories.test.ts
@@ -21,8 +21,8 @@ describe('buildRlsDisabledAdvisory', () => {
     expect(advisory!.message).not.toContain('public.posts');
     expect(advisory!.message).toContain('2 table(s)');
     expect(advisory!.remediation_sql).toBe(
-      'ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;\n' +
-        'ALTER TABLE public.comments ENABLE ROW LEVEL SECURITY;'
+      'ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;\n' +
+        'ALTER TABLE "public"."comments" ENABLE ROW LEVEL SECURITY;'
     );
     expect(advisory!.doc_url).toContain('row-level-security');
   });
@@ -66,7 +66,7 @@ describe('buildRlsDisabledAdvisory', () => {
     expect(advisory!.message).toContain('public.profiles');
     expect(advisory!.message).not.toContain('auth.users');
     expect(advisory!.remediation_sql).toBe(
-      'ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;'
+      'ALTER TABLE "public"."profiles" ENABLE ROW LEVEL SECURITY;'
     );
   });
 
@@ -81,6 +81,19 @@ describe('buildRlsDisabledAdvisory', () => {
     expect(advisory).not.toBeNull();
     expect(advisory!.message).toContain('myapp.orders');
     expect(advisory!.message).toContain('api.products');
+  });
+
+  test('quotes identifiers containing special characters in remediation SQL', () => {
+    const tables = [
+      { name: 'public.foo"; DROP TABLE bar; --', rls_enabled: false },
+    ];
+
+    const advisory = buildRlsDisabledAdvisory(tables);
+
+    expect(advisory).not.toBeNull();
+    expect(advisory!.remediation_sql).toBe(
+      'ALTER TABLE "public"."foo""; DROP TABLE bar; --" ENABLE ROW LEVEL SECURITY;'
+    );
   });
 });
 

--- a/packages/mcp-server-supabase/src/advisories/rls-disabled.ts
+++ b/packages/mcp-server-supabase/src/advisories/rls-disabled.ts
@@ -34,6 +34,26 @@ const SYSTEM_SCHEMAS = new Set([
 ]);
 
 /**
+ * Quotes a Postgres identifier, doubling any embedded double quotes.
+ */
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Quotes a `schema.table` name for safe use in generated SQL, quoting the
+ * schema and table portions independently.
+ */
+function quoteQualifiedName(name: string): string {
+  const dotIndex = name.indexOf('.');
+  if (dotIndex === -1) return quoteIdentifier(name);
+
+  const schema = name.slice(0, dotIndex);
+  const table = name.slice(dotIndex + 1);
+  return `${quoteIdentifier(schema)}.${quoteIdentifier(table)}`;
+}
+
+/**
  * Builds an RLS advisory when any user-schema tables have RLS disabled.
  *
  * Expects table names in `schema.table` format (as returned by `list_tables`).
@@ -50,7 +70,10 @@ export function buildRlsDisabledAdvisory(
   if (unprotected.length === 0) return null;
 
   const sqlStatements = unprotected
-    .map((t) => `ALTER TABLE ${t.name} ENABLE ROW LEVEL SECURITY;`)
+    .map(
+      (t) =>
+        `ALTER TABLE ${quoteQualifiedName(t.name)} ENABLE ROW LEVEL SECURITY;`
+    )
     .join('\n');
 
   return {

--- a/packages/mcp-server-supabase/src/management-api/types.ts
+++ b/packages/mcp-server-supabase/src/management-api/types.ts
@@ -2770,7 +2770,7 @@ export interface components {
                     hostname: string;
                     ssl: {
                         status: string;
-                        validation_records: {
+                        validation_records?: {
                             txt_name: string;
                             txt_value: string;
                         }[];
@@ -2778,7 +2778,7 @@ export interface components {
                             message: string;
                         }[];
                     };
-                    ownership_verification: {
+                    ownership_verification?: {
                         type: string;
                         name: string;
                         value: string;
@@ -6903,7 +6903,7 @@ export interface operations {
                         /** @constant */
                         state: "unavailable";
                         /** @enum {string} */
-                        unavailableReason: "postgres_upgrade_required" | "ssl_enforcement_required" | "temporarily_unavailable";
+                        unavailableReason: "platform_unsupported" | "postgres_upgrade_required" | "ssl_enforcement_required" | "temporarily_unavailable";
                     };
                 };
             };
@@ -6966,7 +6966,7 @@ export interface operations {
                         /** @constant */
                         state: "unavailable";
                         /** @enum {string} */
-                        unavailableReason: "postgres_upgrade_required" | "ssl_enforcement_required" | "temporarily_unavailable";
+                        unavailableReason: "platform_unsupported" | "postgres_upgrade_required" | "ssl_enforcement_required" | "temporarily_unavailable";
                     };
                 };
             };
@@ -11613,7 +11613,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FunctionResponse_Output"];
+                    "application/json": components["schemas"]["FunctionSlugResponse_Output"];
                 };
             };
             /** @description Unauthorized */

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -1490,7 +1490,8 @@ describe('tools', () => {
         level: 'critical',
         title: 'Row Level Security is disabled',
         message: expect.stringContaining('public.test'),
-        remediation_sql: 'ALTER TABLE public.test ENABLE ROW LEVEL SECURITY;',
+        remediation_sql:
+          'ALTER TABLE "public"."test" ENABLE ROW LEVEL SECURITY;',
         doc_url: expect.stringContaining('row-level-security'),
       },
     });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Table names were not escaped in rls advisor.

## What is the new behavior?

Escapes table names to ensure valid SQL in the suggested ALTER TABLE statement.

