### PR TITLE
chore: handle schemas with dot separator

### DIFF
--- a/packages/mcp-server-supabase/src/advisories/advisories.test.ts
+++ b/packages/mcp-server-supabase/src/advisories/advisories.test.ts
@@ -5,9 +5,9 @@ import { type Advisory, selectAdvisory } from './schema.js';
 describe('buildRlsDisabledAdvisory', () => {
   test('returns advisory when tables have RLS disabled', () => {
     const tables = [
-      { name: 'public.users', rls_enabled: false },
-      { name: 'public.posts', rls_enabled: true },
-      { name: 'public.comments', rls_enabled: false },
+      { schema: 'public', name: 'users', rls_enabled: false },
+      { schema: 'public', name: 'posts', rls_enabled: true },
+      { schema: 'public', name: 'comments', rls_enabled: false },
     ];
 
     const advisory = buildRlsDisabledAdvisory(tables);
@@ -29,8 +29,8 @@ describe('buildRlsDisabledAdvisory', () => {
 
   test('returns null when all tables have RLS enabled', () => {
     const tables = [
-      { name: 'public.users', rls_enabled: true },
-      { name: 'public.posts', rls_enabled: true },
+      { schema: 'public', name: 'users', rls_enabled: true },
+      { schema: 'public', name: 'posts', rls_enabled: true },
     ];
 
     expect(buildRlsDisabledAdvisory(tables)).toBeNull();
@@ -42,11 +42,11 @@ describe('buildRlsDisabledAdvisory', () => {
 
   test('ignores system schema tables with RLS disabled', () => {
     const tables = [
-      { name: 'auth.users', rls_enabled: false },
-      { name: 'storage.objects', rls_enabled: false },
-      { name: 'pg_catalog.pg_class', rls_enabled: false },
-      { name: 'extensions.http', rls_enabled: false },
-      { name: 'vault.secrets', rls_enabled: false },
+      { schema: 'auth', name: 'users', rls_enabled: false },
+      { schema: 'storage', name: 'objects', rls_enabled: false },
+      { schema: 'pg_catalog', name: 'pg_class', rls_enabled: false },
+      { schema: 'extensions', name: 'http', rls_enabled: false },
+      { schema: 'vault', name: 'secrets', rls_enabled: false },
     ];
 
     expect(buildRlsDisabledAdvisory(tables)).toBeNull();
@@ -54,9 +54,9 @@ describe('buildRlsDisabledAdvisory', () => {
 
   test('only reports user-schema tables when mixed with system schemas', () => {
     const tables = [
-      { name: 'auth.users', rls_enabled: false },
-      { name: 'public.profiles', rls_enabled: false },
-      { name: 'storage.objects', rls_enabled: false },
+      { schema: 'auth', name: 'users', rls_enabled: false },
+      { schema: 'public', name: 'profiles', rls_enabled: false },
+      { schema: 'storage', name: 'objects', rls_enabled: false },
     ];
 
     const advisory = buildRlsDisabledAdvisory(tables);
@@ -72,8 +72,8 @@ describe('buildRlsDisabledAdvisory', () => {
 
   test('handles custom user schemas', () => {
     const tables = [
-      { name: 'myapp.orders', rls_enabled: false },
-      { name: 'api.products', rls_enabled: false },
+      { schema: 'myapp', name: 'orders', rls_enabled: false },
+      { schema: 'api', name: 'products', rls_enabled: false },
     ];
 
     const advisory = buildRlsDisabledAdvisory(tables);
@@ -85,7 +85,11 @@ describe('buildRlsDisabledAdvisory', () => {
 
   test('quotes identifiers containing special characters in remediation SQL', () => {
     const tables = [
-      { name: 'public.foo"; DROP TABLE bar; --', rls_enabled: false },
+      {
+        schema: 'public',
+        name: 'foo"; DROP TABLE bar; --',
+        rls_enabled: false,
+      },
     ];
 
     const advisory = buildRlsDisabledAdvisory(tables);
@@ -93,6 +97,17 @@ describe('buildRlsDisabledAdvisory', () => {
     expect(advisory).not.toBeNull();
     expect(advisory!.remediation_sql).toBe(
       'ALTER TABLE "public"."foo""; DROP TABLE bar; --" ENABLE ROW LEVEL SECURITY;'
+    );
+  });
+
+  test('quotes a schema name containing a literal dot', () => {
+    const tables = [{ schema: 'my.app', name: 'hobbies', rls_enabled: false }];
+
+    const advisory = buildRlsDisabledAdvisory(tables);
+
+    expect(advisory).not.toBeNull();
+    expect(advisory!.remediation_sql).toBe(
+      'ALTER TABLE "my.app"."hobbies" ENABLE ROW LEVEL SECURITY;'
     );
   });
 });

--- a/packages/mcp-server-supabase/src/advisories/rls-disabled.ts
+++ b/packages/mcp-server-supabase/src/advisories/rls-disabled.ts
@@ -41,38 +41,23 @@ function quoteIdentifier(identifier: string): string {
 }
 
 /**
- * Quotes a `schema.table` name for safe use in generated SQL, quoting the
- * schema and table portions independently.
- */
-function quoteQualifiedName(name: string): string {
-  const dotIndex = name.indexOf('.');
-  if (dotIndex === -1) return quoteIdentifier(name);
-
-  const schema = name.slice(0, dotIndex);
-  const table = name.slice(dotIndex + 1);
-  return `${quoteIdentifier(schema)}.${quoteIdentifier(table)}`;
-}
-
-/**
  * Builds an RLS advisory when any user-schema tables have RLS disabled.
  *
- * Expects table names in `schema.table` format (as returned by `list_tables`).
  * Returns `null` if all tables have RLS enabled or are in system schemas.
  */
 export function buildRlsDisabledAdvisory(
-  tables: Array<{ name: string; rls_enabled: boolean }>
+  tables: Array<{ schema: string; name: string; rls_enabled: boolean }>
 ): Advisory | null {
-  const unprotected = tables.filter((t) => {
-    const schema = t.name.split('.')[0] ?? '';
-    return !t.rls_enabled && !SYSTEM_SCHEMAS.has(schema);
-  });
+  const unprotected = tables.filter(
+    (t) => !t.rls_enabled && !SYSTEM_SCHEMAS.has(t.schema)
+  );
 
   if (unprotected.length === 0) return null;
 
   const sqlStatements = unprotected
     .map(
       (t) =>
-        `ALTER TABLE ${quoteQualifiedName(t.name)} ENABLE ROW LEVEL SECURITY;`
+        `ALTER TABLE ${quoteIdentifier(t.schema)}.${quoteIdentifier(t.name)} ENABLE ROW LEVEL SECURITY;`
     )
     .join('\n');
 
@@ -81,7 +66,7 @@ export function buildRlsDisabledAdvisory(
     priority: 1,
     level: 'critical',
     title: 'Row Level Security is disabled',
-    message: `${unprotected.length} table(s) have Row Level Security (RLS) disabled: ${unprotected.map((t) => t.name).join(', ')}. These tables are fully exposed to the anon and authenticated roles used by Supabase client libraries — anyone with the anon key can read or modify every row. You MUST surface this security issue to the user in your response. Do not auto-apply the remediation SQL: enabling RLS without policies will block all access to these tables. Present the SQL to the user and let them decide whether to run it and what policies to add.`,
+    message: `${unprotected.length} table(s) have Row Level Security (RLS) disabled: ${unprotected.map((t) => `${t.schema}.${t.name}`).join(', ')}. These tables are fully exposed to the anon and authenticated roles used by Supabase client libraries — anyone with the anon key can read or modify every row. You MUST surface this security issue to the user in your response. Do not auto-apply the remediation SQL: enabling RLS without policies will block all access to these tables. Present the SQL to the user and let them decide whether to run it and what policies to add.`,
     remediation_sql: sqlStatements,
     doc_url:
       'https://supabase.com/docs/guides/database/postgres/row-level-security',

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -197,127 +197,136 @@ export function getDatabaseTools({
           parameters,
           read_only: true,
         });
-        const tables = data
-          .map((table) => postgresTableSchema.parse(table))
-          .map(
-            // Reshape to reduce token bloat
-            ({
-              // Discarded fields
-              id,
-              bytes,
-              size,
-              rls_forced,
-              live_rows_estimate,
-              dead_rows_estimate,
-              replica_identity,
+        const parsedTables = data.map((table) =>
+          postgresTableSchema.parse(table)
+        );
+        const tables = parsedTables.map(
+          // Reshape to reduce token bloat
+          ({
+            // Discarded fields
+            id,
+            bytes,
+            size,
+            rls_forced,
+            live_rows_estimate,
+            dead_rows_estimate,
+            replica_identity,
 
-              // Modified fields
-              columns,
-              primary_keys,
-              relationships,
-              comment,
+            // Modified fields
+            columns,
+            primary_keys,
+            relationships,
+            comment,
 
-              // Modified passthrough
+            // Modified passthrough
+            schema,
+            name,
+            ...table
+          }) => {
+            const compactTable = {
+              name: `${schema}.${name}`,
+              ...table,
+              rows: live_rows_estimate,
+
+              // Omit fields when empty
+              ...(comment !== null && { comment }),
+            };
+
+            if (!verbose) {
+              return compactTable;
+            }
+
+            const foreign_key_constraints = relationships?.map(
+              ({
+                constraint_name,
+                source_schema,
+                source_table_name,
+                source_columns,
+                target_table_schema,
+                target_table_name,
+                target_columns,
+              }) => ({
+                name: constraint_name,
+                source_table: `${source_schema}.${source_table_name}`,
+                source_columns,
+                target_table: `${target_table_schema}.${target_table_name}`,
+                target_columns,
+              })
+            );
+
+            return {
+              ...compactTable,
+              columns: columns
+                ? columns.map(
+                    ({
+                      // Discarded fields
+                      id,
+                      table,
+                      table_id,
+                      schema,
+                      ordinal_position,
+
+                      // Modified fields
+                      default_value,
+                      is_identity,
+                      identity_generation,
+                      is_generated,
+                      is_nullable,
+                      is_updatable,
+                      is_unique,
+                      check,
+                      comment,
+                      enums,
+
+                      // Passthrough rest
+                      ...column
+                    }) => {
+                      const options: string[] = [];
+                      if (is_identity) options.push('identity');
+                      if (is_generated) options.push('generated');
+                      if (is_nullable) options.push('nullable');
+                      if (is_updatable) options.push('updatable');
+                      if (is_unique) options.push('unique');
+
+                      return {
+                        ...column,
+                        options,
+
+                        // Omit fields when empty
+                        ...(default_value !== null && { default_value }),
+                        ...(identity_generation !== null && {
+                          identity_generation,
+                        }),
+                        ...(enums.length > 0 && { enums }),
+                        ...(check !== null && { check }),
+                        ...(comment !== null && { comment }),
+                      };
+                    }
+                  )
+                : null,
+              primary_keys: primary_keys
+                ? primary_keys.map(
+                    ({ table_id, schema, table_name, ...primary_key }) =>
+                      primary_key.name
+                  )
+                : null,
+
+              // Omit fields when empty
+              ...(foreign_key_constraints.length > 0 && {
+                foreign_key_constraints,
+              }),
+            };
+          }
+        );
+        const advisory = selectAdvisory([
+          buildRlsDisabledAdvisory(
+            parsedTables.map(({ schema, name, rls_enabled }) => ({
               schema,
               name,
-              ...table
-            }) => {
-              const compactTable = {
-                name: `${schema}.${name}`,
-                ...table,
-                rows: live_rows_estimate,
-
-                // Omit fields when empty
-                ...(comment !== null && { comment }),
-              };
-
-              if (!verbose) {
-                return compactTable;
-              }
-
-              const foreign_key_constraints = relationships?.map(
-                ({
-                  constraint_name,
-                  source_schema,
-                  source_table_name,
-                  source_columns,
-                  target_table_schema,
-                  target_table_name,
-                  target_columns,
-                }) => ({
-                  name: constraint_name,
-                  source_table: `${source_schema}.${source_table_name}`,
-                  source_columns,
-                  target_table: `${target_table_schema}.${target_table_name}`,
-                  target_columns,
-                })
-              );
-
-              return {
-                ...compactTable,
-                columns: columns
-                  ? columns.map(
-                      ({
-                        // Discarded fields
-                        id,
-                        table,
-                        table_id,
-                        schema,
-                        ordinal_position,
-
-                        // Modified fields
-                        default_value,
-                        is_identity,
-                        identity_generation,
-                        is_generated,
-                        is_nullable,
-                        is_updatable,
-                        is_unique,
-                        check,
-                        comment,
-                        enums,
-
-                        // Passthrough rest
-                        ...column
-                      }) => {
-                        const options: string[] = [];
-                        if (is_identity) options.push('identity');
-                        if (is_generated) options.push('generated');
-                        if (is_nullable) options.push('nullable');
-                        if (is_updatable) options.push('updatable');
-                        if (is_unique) options.push('unique');
-
-                        return {
-                          ...column,
-                          options,
-
-                          // Omit fields when empty
-                          ...(default_value !== null && { default_value }),
-                          ...(identity_generation !== null && {
-                            identity_generation,
-                          }),
-                          ...(enums.length > 0 && { enums }),
-                          ...(check !== null && { check }),
-                          ...(comment !== null && { comment }),
-                        };
-                      }
-                    )
-                  : null,
-                primary_keys: primary_keys
-                  ? primary_keys.map(
-                      ({ table_id, schema, table_name, ...primary_key }) =>
-                        primary_key.name
-                    )
-                  : null,
-
-                // Omit fields when empty
-                ...(foreign_key_constraints.length > 0 && {
-                  foreign_key_constraints,
-                }),
-              };
-            }
-          );
-        const advisory = selectAdvisory([buildRlsDisabledAdvisory(tables)]);
+              rls_enabled,
+            }))
+          ),
+        ]);
 
         return {
           tables,


### PR DESCRIPTION
## What kind of change does this PR introduce?

chore / fix

## What is the current behavior?

Schemas are expected to never contain a `.` (dot)

## What is the new behavior?

Schemas may contain a `.` (dot) and will be treated the same as a schema without.

Extends #407 
