### PR TITLE
feat(mcp): hide legacy cost tools from form-capable clients

### DIFF
--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -682,6 +682,36 @@ describe('tools', () => {
       expect(names).toContain('create_project');
     });
 
+    test('omits confirm_cost_id from create_project for a form-capable client', async () => {
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
+
+      const { tools } = await client.listTools();
+      const createProjectTool = tools.find(
+        (tool) => tool.name === 'create_project'
+      );
+
+      expect(createProjectTool?.inputSchema.properties).not.toHaveProperty(
+        'confirm_cost_id'
+      );
+    });
+
+    test('omits confirm_cost_id from create_branch for a form-capable client', async () => {
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
+
+      const { tools } = await client.listTools();
+      const createBranchTool = tools.find(
+        (tool) => tool.name === 'create_branch'
+      );
+
+      expect(createBranchTool?.inputSchema.properties).not.toHaveProperty(
+        'confirm_cost_id'
+      );
+    });
+
     test('narrows cost tools to branch while create_branch still needs confirm_cost_id', async () => {
       const { client } = await setupModern({
         clientCapabilities: FORM_CAPABLE,
@@ -4161,7 +4191,7 @@ describe('tools', () => {
       }
     });
 
-    test('form-capable client: a supplied confirm_cost_id cannot bypass the form', async () => {
+    test('form-capable client: a supplied confirm_cost_id is rejected', async () => {
       const { client } = await setupModern({
         clientCapabilities: FORM_CAPABLE,
       });
@@ -4179,8 +4209,8 @@ describe('tools', () => {
       });
       project.status = 'ACTIVE_HEALTHY';
 
-      // The correct legacy hash - even a valid confirmation ID must not
-      // let a form-capable client skip straight to creation.
+      // The correct legacy hash. The field is not part of this client's
+      // schema, so even a valid confirmation ID must not reach creation.
       const legacyConfirmCostId = await hashObject(getBranchCost());
 
       const result = (await client.request(
@@ -4198,9 +4228,10 @@ describe('tools', () => {
         { allowInputRequired: true }
       )) as CallToolResult | InputRequiredResult;
 
-      if (!isInputRequiredResult(result)) {
-        throw new Error('expected an input_required result');
+      if (isInputRequiredResult(result)) {
+        throw new Error('expected a tool error, not an input_required result');
       }
+      expect(result.isError).toBe(true);
       expect(mockBranches.size).toBe(0);
     });
 

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -6,6 +6,7 @@ import {
 import type {
   CallToolRequestParams,
   CallToolResult,
+  ClientCapabilities,
   InputRequiredResult,
 } from '@modelcontextprotocol/client';
 import { StreamTransport } from '@supabase/mcp-utils';
@@ -67,6 +68,7 @@ type SetupOptions = {
   readOnly?: boolean;
   features?: string[];
   costConfirmation?: SupabaseMcpServerOptions['costConfirmation'];
+  clientCapabilities?: ClientCapabilities;
 };
 
 /**
@@ -79,6 +81,7 @@ async function setup(options: SetupOptions = {}) {
     readOnly,
     features,
     costConfirmation,
+    clientCapabilities = {},
   } = options;
   const clientTransport = new StreamTransport();
   const serverTransport = new StreamTransport();
@@ -92,7 +95,7 @@ async function setup(options: SetupOptions = {}) {
       version: MCP_CLIENT_VERSION,
     },
     {
-      capabilities: {},
+      capabilities: clientCapabilities,
     }
   );
 
@@ -148,7 +151,9 @@ async function setup(options: SetupOptions = {}) {
   return { client, clientTransport, callTool, server, serverTransport };
 }
 
-type FormCapableSetupOptions = {
+type ModernSetupOptions = {
+  costConfirmation?: SupabaseMcpServerOptions['costConfirmation'];
+  clientCapabilities?: ClientCapabilities;
   readOnly?: boolean;
   projectId?: string;
   /**
@@ -167,6 +172,8 @@ const COST_CONFIRMATION: NonNullable<
   enabledTools: ['create_project', 'create_branch'],
 };
 
+const FORM_CAPABLE: ClientCapabilities = { elicitation: { form: {} } };
+
 // https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
 const MODERN_PROTOCOL_VERSION = '2026-07-28';
 const MCP_ENDPOINT = new URL('https://mcp.test');
@@ -174,14 +181,20 @@ const MCP_ENDPOINT = new URL('https://mcp.test');
 /**
  * Sets up an MCP client against the hosted HTTP handler (in-process, via a
  * custom `fetch`) for the `create_project`/`create_branch` cost-confirmation
- * elicitation lanes: a client pinned to the 2026-07-28 protocol, declaring
- * per-request form capability. Raw `StreamTransport` only speaks the 2025
+ * elicitation lanes: a client pinned to the 2026-07-28 protocol whose
+ * capabilities ride along on every request. Raw `StreamTransport` only speaks the 2025
  * era, so the form-capable lane - which depends on the per-request `_meta`
  * envelope - needs the same in-process HTTP transport the hosted runtime
  * uses.
  */
-async function setupFormCapable(options: FormCapableSetupOptions = {}) {
-  const { readOnly, projectId, elicitationAction } = options;
+async function setupModern(options: ModernSetupOptions = {}) {
+  const {
+    readOnly,
+    projectId,
+    elicitationAction,
+    costConfirmation = COST_CONFIRMATION,
+    clientCapabilities = {},
+  } = options;
 
   const platform = createSupabaseApiPlatform({
     accessToken: ACCESS_TOKEN,
@@ -201,7 +214,7 @@ async function setupFormCapable(options: FormCapableSetupOptions = {}) {
     platform,
     projectId,
     readOnly,
-    costConfirmation: COST_CONFIRMATION,
+    costConfirmation,
   });
 
   const transport = new StreamableHTTPClientTransport(MCP_ENDPOINT, {
@@ -211,7 +224,7 @@ async function setupFormCapable(options: FormCapableSetupOptions = {}) {
   const client = new Client(
     { name: MCP_CLIENT_NAME, version: MCP_CLIENT_VERSION },
     {
-      capabilities: { elicitation: { form: {} } },
+      capabilities: clientCapabilities,
       versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } },
       ...(elicitationAction === undefined && {
         inputRequired: { autoFulfill: false },
@@ -655,6 +668,77 @@ describe('tools', () => {
       );
     });
 
+    test('hides cost tools from a form-capable client', async () => {
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+        costConfirmation: COST_CONFIRMATION,
+      });
+
+      const { tools } = await client.listTools();
+      const names = tools.map((tool) => tool.name);
+
+      expect(names).not.toContain('get_cost');
+      expect(names).not.toContain('confirm_cost');
+      expect(names).toContain('create_project');
+    });
+
+    test('narrows cost tools to branch while create_branch still needs confirm_cost_id', async () => {
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+        costConfirmation: {
+          ...COST_CONFIRMATION,
+          enabledTools: ['create_project'],
+        },
+      });
+
+      const { tools } = await client.listTools();
+
+      for (const name of ['get_cost', 'confirm_cost']) {
+        const tool = tools.find((tool) => tool.name === name);
+        expect(tool?.inputSchema.properties?.type).toStrictEqual({
+          type: 'string',
+          enum: ['branch'],
+        });
+      }
+    });
+
+    test('lists cost tools for a 2025-era client that declares elicitation', async () => {
+      const { client } = await setup({
+        costConfirmation: COST_CONFIRMATION,
+        clientCapabilities: { elicitation: { form: {} } },
+      });
+
+      const { tools } = await client.listTools();
+      const names = tools.map((tool) => tool.name);
+
+      expect(names).toContain('get_cost');
+      expect(names).toContain('confirm_cost');
+    });
+
+    test('lists cost tools for a modern client without elicitation', async () => {
+      const { client } = await setupModern({
+        costConfirmation: COST_CONFIRMATION,
+      });
+
+      const { tools } = await client.listTools();
+      const names = tools.map((tool) => tool.name);
+
+      expect(names).toContain('get_cost');
+      expect(names).toContain('confirm_cost');
+    });
+
+    test('lists cost tools for a capability-free client', async () => {
+      const { client } = await setup({
+        costConfirmation: COST_CONFIRMATION,
+      });
+
+      const { tools } = await client.listTools();
+      const names = tools.map((tool) => tool.name);
+
+      expect(names).toContain('get_cost');
+      expect(names).toContain('confirm_cost');
+    });
+
     test('capability-free client still succeeds via get_cost -> confirm_cost -> create_project', async () => {
       const { callTool } = await setup({
         costConfirmation: COST_CONFIRMATION,
@@ -690,7 +774,9 @@ describe('tools', () => {
     });
 
     test('form-capable client: $0 creates without elicitation', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
 
       const freeOrg = await createOrganization({
         name: 'Free Org',
@@ -722,7 +808,8 @@ describe('tools', () => {
     });
 
     test('form-capable client: accept creates the project exactly once', async () => {
-      const { client } = await setupFormCapable({
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
         elicitationAction: 'accept',
       });
       const { org } = await createOrganizationWithBillableNextProject();
@@ -751,7 +838,8 @@ describe('tools', () => {
     });
 
     test('form-capable client: decline does not create a project', async () => {
-      const { client } = await setupFormCapable({
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
         elicitationAction: 'decline',
       });
       const { org } = await createOrganizationWithBillableNextProject();
@@ -771,7 +859,8 @@ describe('tools', () => {
     });
 
     test('form-capable client: cancel does not create a project', async () => {
-      const { client } = await setupFormCapable({
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
         elicitationAction: 'cancel',
       });
       const { org } = await createOrganizationWithBillableNextProject();
@@ -791,7 +880,9 @@ describe('tools', () => {
     });
 
     test('rejects a retry whose arguments changed since the state was minted', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
       const { org } = await createOrganizationWithBillableNextProject();
       const otherOrg = await createOrganization({
         name: 'Other Org',
@@ -847,7 +938,9 @@ describe('tools', () => {
     });
 
     test('creates without re-prompting when the quoted cost drops to zero before confirmation', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
       const { org, existingProject } =
         await createOrganizationWithBillableNextProject();
 
@@ -895,7 +988,9 @@ describe('tools', () => {
     });
 
     test('a decline is honored even when the quoted cost changed since the state was minted', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
       const { org, existingProject } =
         await createOrganizationWithBillableNextProject();
 
@@ -3826,7 +3921,8 @@ describe('tools', () => {
     });
 
     test('form-capable client: accept creates the branch exactly once', async () => {
-      const { client } = await setupFormCapable({
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
         elicitationAction: 'accept',
       });
 
@@ -3866,7 +3962,8 @@ describe('tools', () => {
     });
 
     test('form-capable client: decline does not create a branch', async () => {
-      const { client } = await setupFormCapable({
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
         elicitationAction: 'decline',
       });
 
@@ -3894,7 +3991,8 @@ describe('tools', () => {
     });
 
     test('form-capable client: cancel does not create a branch', async () => {
-      const { client } = await setupFormCapable({
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
         elicitationAction: 'cancel',
       });
 
@@ -3922,7 +4020,9 @@ describe('tools', () => {
     });
 
     test('form-capable client: a non-elicitation response re-prompts without creating a branch', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
 
       const org = await createOrganization({
         name: 'My Org',
@@ -3982,7 +4082,9 @@ describe('tools', () => {
           amount: BRANCH_COST_HOURLY + 1,
         });
       try {
-        const { client } = await setupFormCapable();
+        const { client } = await setupModern({
+          clientCapabilities: FORM_CAPABLE,
+        });
 
         const org = await createOrganization({
           name: 'My Org',
@@ -4060,7 +4162,9 @@ describe('tools', () => {
     });
 
     test('form-capable client: a supplied confirm_cost_id cannot bypass the form', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
 
       const org = await createOrganization({
         name: 'My Org',
@@ -4101,7 +4205,9 @@ describe('tools', () => {
     });
 
     test('rejects a retry whose arguments changed since the state was minted', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
 
       const org = await createOrganization({
         name: 'My Org',
@@ -4169,7 +4275,8 @@ describe('tools', () => {
       });
       project.status = 'ACTIVE_HEALTHY';
 
-      const { client } = await setupFormCapable({
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
         projectId: project.id,
         elicitationAction: 'accept',
       });
@@ -4205,7 +4312,9 @@ describe('tools', () => {
     });
 
     test('rejects a requestState minted by create_project', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
 
       // create_project only triggers cost confirmation for a paid org's
       // additional projects, so set up a pro org with one existing project.
@@ -4274,7 +4383,9 @@ describe('tools', () => {
     });
 
     test('rejects a tampered requestState before the handler runs', async () => {
-      const { client } = await setupFormCapable();
+      const { client } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
 
       const org = await createOrganization({
         name: 'My Org',
@@ -4993,7 +5104,11 @@ describe('tools', () => {
     // query_logs).
     const registryToolNames = Object.keys(supabaseMcpToolSchemas);
     const serverToolNames = tools.map((t) => t.name);
-    const conditionallyHiddenToolNames = new Set(['get_logs']);
+    const conditionallyHiddenToolNames = new Set([
+      'get_logs',
+      'get_cost',
+      'confirm_cost',
+    ]);
 
     const extraToolsInRegistry = registryToolNames.filter(
       (name) => !serverToolNames.includes(name)

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -181,9 +181,9 @@ const MCP_ENDPOINT = new URL('https://mcp.test');
 /**
  * Sets up an MCP client against the hosted HTTP handler (in-process, via a
  * custom `fetch`) for the `create_project`/`create_branch` cost-confirmation
- * elicitation lanes: a client pinned to the 2026-07-28 protocol whose
- * capabilities ride along on every request. Raw `StreamTransport` only speaks the 2025
- * era, so the form-capable lane - which depends on the per-request `_meta`
+ * elicitation lanes: a client pinned to the 2026-07-28 protocol. Raw
+ * `StreamTransport` only speaks the 2025 era, so the form-capable lane - which
+ * depends on the per-request `_meta`
  * envelope - needs the same in-process HTTP transport the hosted runtime
  * uses.
  */

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -257,12 +257,28 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         }
       }
 
-      // Form-capable clients confirm cost inside the create tools, so the
-      // legacy cost tools only offer the types that still need them. With
-      // nothing left to quote they are hidden entirely.
-      if (costConfirmationCodec && ctx && isFormCapable(ctx)) {
+      // Form-capable clients confirm cost inside the create tools, so those
+      // drop `confirm_cost_id` and the legacy cost tools only offer the types
+      // that still need them. With nothing left to quote they are hidden
+      // entirely.
+      if (
+        costConfirmationCodec &&
+        costConfirmation &&
+        ctx &&
+        isFormCapable(ctx)
+      ) {
+        for (const name of costConfirmation.enabledTools) {
+          const tool = tools[name];
+          if (tool) {
+            tools[name] = {
+              ...tool,
+              parameters: tool.parameters.omit({ confirm_cost_id: true }),
+            };
+          }
+        }
+
         const legacyCostTypes = (['project', 'branch'] as const).filter(
-          (type) => !costConfirmation?.enabledTools.includes(`create_${type}`)
+          (type) => !costConfirmation.enabledTools.includes(`create_${type}`)
         );
         for (const name of ['get_cost', 'confirm_cost']) {
           const tool = tools[name];

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -9,7 +9,10 @@ import { createContentApiClient } from './content-api/index.js';
 import type { SupabasePlatform } from './platform/types.js';
 import { getAccountTools } from './tools/account-tools.js';
 import { getBranchingTools } from './tools/branching-tools.js';
-import type { CostConfirmationState } from './tools/cost-confirmation.js';
+import {
+  type CostConfirmationState,
+  isFormCapable,
+} from './tools/cost-confirmation.js';
 import { getDatabaseTools } from './tools/database-operation-tools.js';
 import { getDebuggingTools } from './tools/debugging-tools.js';
 import { getDevelopmentTools } from './tools/development-tools.js';
@@ -19,6 +22,7 @@ import { getStorageTools } from './tools/storage-tools.js';
 import { writeToolSet } from './tools/tool-schemas.js';
 import type { FeatureGroup } from './types.js';
 import { parseFeatureGroups } from './util.js';
+import { z } from 'zod/v4';
 
 const { version } = packageJson;
 
@@ -166,7 +170,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     requestState: costConfirmationCodec && {
       verify: costConfirmationCodec.verify,
     },
-    tools: async () => {
+    tools: async (ctx) => {
       const contentApiClient = await contentApiClientPromise;
       const tools: Record<string, Tool> = {};
 
@@ -253,9 +257,36 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         }
       }
 
+      // Form-capable clients confirm cost inside the create tools, so the
+      // legacy cost tools only offer the types that still need them. With
+      // nothing left to quote they are hidden entirely.
+      if (costConfirmationCodec && ctx && isFormCapable(ctx)) {
+        const legacyCostTypes = (['project', 'branch'] as const).filter(
+          (type) => !costConfirmation?.enabledTools.includes(`create_${type}`)
+        );
+        for (const name of ['get_cost', 'confirm_cost']) {
+          const tool = tools[name];
+          if (!tool) {
+            continue;
+          }
+          tools[name] = isNonEmpty(legacyCostTypes)
+            ? {
+                ...tool,
+                parameters: tool.parameters.extend({
+                  type: z.enum(legacyCostTypes),
+                }),
+              }
+            : { ...tool, hidden: true };
+        }
+      }
+
       return tools;
     },
   });
 
   return server;
+}
+
+function isNonEmpty<T>(items: readonly T[]): items is readonly [T, ...T[]] {
+  return items.length > 0;
 }

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -267,9 +267,13 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         ctx &&
         isFormCapable(ctx)
       ) {
-        for (const name of costConfirmation.enabledTools) {
+        const legacyCostTypes: ('project' | 'branch')[] = [];
+        for (const type of ['project', 'branch'] as const) {
+          const name = `create_${type}` as const;
           const tool = tools[name];
-          if (tool) {
+          if (!costConfirmation.enabledTools.includes(name)) {
+            legacyCostTypes.push(type);
+          } else if (tool) {
             tools[name] = {
               ...tool,
               parameters: tool.parameters.omit({ confirm_cost_id: true }),
@@ -277,9 +281,6 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
           }
         }
 
-        const legacyCostTypes = (['project', 'branch'] as const).filter(
-          (type) => !costConfirmation.enabledTools.includes(`create_${type}`)
-        );
         for (const name of ['get_cost', 'confirm_cost']) {
           const tool = tools[name];
           if (!tool) {

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -272,7 +272,11 @@ export type McpServerOptions = {
    * asks for the list of tools or invokes a tool. This allows for dynamic tools
    * that can change after the server has started.
    */
-  tools?: Prop<Record<string, Tool>>;
+  tools?:
+    | Record<string, Tool>
+    | ((
+        ctx?: ServerContext
+      ) => Record<string, Tool> | Promise<Record<string, Tool>>);
 
   /**
    * Multi-round-trip `requestState` integrity hook (protocol revision
@@ -327,13 +331,13 @@ export function createMcpServer(options: McpServerOptions) {
       : options.resources;
   }
 
-  async function getTools() {
+  async function getTools(ctx?: ServerContext) {
     if (!options.tools) {
       throw new Error('tools not available');
     }
 
     return typeof options.tools === 'function'
-      ? await options.tools()
+      ? await options.tools(ctx)
       : options.tools;
   }
 
@@ -469,8 +473,8 @@ export function createMcpServer(options: McpServerOptions) {
   if (options.tools) {
     server.setRequestHandler(
       'tools/list',
-      async (): Promise<ListToolsResult> => {
-        const tools = await getTools();
+      async (_request, ctx): Promise<ListToolsResult> => {
+        const tools = await getTools(ctx);
 
         return {
           tools: await Promise.all(
@@ -500,7 +504,7 @@ export function createMcpServer(options: McpServerOptions) {
 
     server.setRequestHandler('tools/call', async (request, ctx) => {
       try {
-        const tools = await getTools();
+        const tools = await getTools(ctx);
         const toolName = request.params.name;
 
         if (!(toolName in tools)) {


### PR DESCRIPTION
Makes `tools/list` adapt to `costConfirmation.enabledTools` to prevent supported clients from getting prompted twice, from both the legacy tools and elicitation strategy, surfaced when testing https://github.com/supabase/platform/pull/37717

The `tools` callback now receives the per-request `ServerContext` so `tools/list` can vary by client: 
- If both `create_project` and `create_branch` are in `costConfirmation.enabledTools`, `get_cost` and `confirm_cost` are no longer advertised. They stay callable, so a client that already knows the names keeps working.
- If only one `create_` tool is enabled, the two cost tools are still advertised because the other `create_` tool still needs a `confirm_cost_id`, but their `type` argument is narrowed.
- `create_project` and `create_branch` drop `confirm_cost_id` when they're in `enabledTools`, since a form-capable client confirms inline and never needs it.

Legacy clients are unaffected.

## How to review

Run the server over HTTP w/ `costConfirmation` enabled for both tools and connect a form-capable client (e.g. Claude Code w/ the SDK v2 flag as described [here](https://github.com/supabase/mcp/pull/394#pullrequestreview-5097736337)). The tool list should have no `get_cost` or `confirm_cost`, and `create_project` no longer has a `confirm_cost_id` argument. Connect again without declaring `elicitation` and both tools are back.

## Notes

I renamed the test helper `setupFormCapable` to `setupModern` and made its capabilities explicit via a `FORM_CAPABLE` constant, because technically legacy clients can have form capabilities.

The #391 test "a supplied `confirm_cost_id` cannot bypass the form" is now "is rejected". The field isn't in a form-capable client's schema anymore, so strict arg parsing errors instead of routing to the form.

