### PR TITLE
feat(advisors): add health advisor support

### DIFF
--- a/packages/mcp-server-supabase/src/platform/api-platform.ts
+++ b/packages/mcp-server-supabase/src/platform/api-platform.ts
@@ -12,6 +12,7 @@ import {
   assertSuccess,
   createManagementApiClient,
 } from '../management-api/index.js';
+import { createPlatformApiClient } from '../platform-api/index.js';
 import { generatePassword } from '../password.js';
 import {
   applyMigrationOptionsSchema,
@@ -73,6 +74,10 @@ export function createSupabaseApiPlatform(
   const managementApiUrl = apiUrl ?? 'https://api.supabase.com';
 
   let managementApiClient = createManagementApiClient(
+    managementApiUrl,
+    accessToken
+  );
+  let platformApiClient = createPlatformApiClient(
     managementApiUrl,
     accessToken
   );
@@ -335,6 +340,26 @@ export function createSupabaseApiPlatform(
       assertSuccess(response, 'Failed to fetch performance advisors');
 
       return response.data;
+    },
+    async getHealthAdvisors(projectId: string) {
+      const response = await platformApiClient.GET(
+        '/platform/projects/{ref}/run-lints',
+        {
+          params: {
+            path: {
+              ref: projectId,
+            },
+          },
+        }
+      );
+
+      assertSuccess(response, 'Failed to fetch health advisors');
+
+      return {
+        lints: response.data.filter((lint) =>
+          lint.categories.includes('HEALTH')
+        ),
+      };
     },
   };
 
@@ -824,6 +849,13 @@ export function createSupabaseApiPlatform(
 
       // Re-initialize the management API client with the user agent
       managementApiClient = createManagementApiClient(
+        managementApiUrl,
+        accessToken,
+        {
+          'User-Agent': `supabase-mcp/${version} (${clientInfo.name}/${clientInfo.version})`,
+        }
+      );
+      platformApiClient = createPlatformApiClient(
         managementApiUrl,
         accessToken,
         {

--- a/packages/mcp-server-supabase/src/platform/types.ts
+++ b/packages/mcp-server-supabase/src/platform/types.ts
@@ -235,6 +235,7 @@ export type DebuggingOperations = {
   queryLogs?(projectId: string, options: QueryLogsOptions): Promise<unknown>;
   getSecurityAdvisors(projectId: string): Promise<unknown>;
   getPerformanceAdvisors(projectId: string): Promise<unknown>;
+  getHealthAdvisors(projectId: string): Promise<unknown>;
 };
 
 export const apiKeyTypeSchema = z.enum(['legacy', 'publishable']);

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -3067,6 +3067,21 @@ describe('tools', () => {
             },
           ],
         },
+        {
+          name: 'advisor_check_unavailable',
+          title: 'Advisor Check Unavailable',
+          level: 'WARN',
+          facing: 'EXTERNAL',
+          categories: ['HEALTH'],
+          description: 'The health advisor check is unavailable.',
+          remediation: 'https://supabase.com/docs/guides/platform/health',
+          count: 1,
+          findings: [
+            {
+              detail: 'Database telemetry is temporarily unavailable.',
+            },
+          ],
+        },
       ],
     });
   });

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -2973,6 +2973,17 @@ describe('tools', () => {
                 remediation: 'https://supabase.com/docs/guides/platform/health',
                 cache_key: 'project_not_active',
               },
+              {
+                name: 'advisor_check_unavailable',
+                title: 'Advisor Check Unavailable',
+                level: 'WARN',
+                facing: 'EXTERNAL',
+                categories: ['HEALTH'],
+                description: 'The health advisor check is unavailable.',
+                detail: 'Database telemetry is temporarily unavailable.',
+                remediation: 'https://supabase.com/docs/guides/platform/health',
+                cache_key: 'advisor_check_unavailable',
+              },
             ],
           };
         },
@@ -3151,6 +3162,21 @@ describe('tools', () => {
           findings: [
             {
               detail: 'Health checks cannot run while the project is inactive.',
+            },
+          ],
+        },
+        {
+          name: 'advisor_check_unavailable',
+          title: 'Advisor Check Unavailable',
+          level: 'WARN',
+          facing: 'EXTERNAL',
+          categories: ['HEALTH'],
+          description: 'The health advisor check is unavailable.',
+          remediation: 'https://supabase.com/docs/guides/platform/health',
+          count: 1,
+          findings: [
+            {
+              detail: 'Database telemetry is temporarily unavailable.',
             },
           ],
         },

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -2958,6 +2958,24 @@ describe('tools', () => {
             ],
           };
         },
+        async getHealthAdvisors() {
+          return {
+            lints: [
+              {
+                name: 'project_not_active',
+                title: 'Project Not Active',
+                level: 'INFO',
+                facing: 'EXTERNAL',
+                categories: ['HEALTH'],
+                description: 'The project is inactive.',
+                detail:
+                  'Health checks cannot run while the project is inactive.',
+                remediation: 'https://supabase.com/docs/guides/platform/health',
+                cache_key: 'project_not_active',
+              },
+            ],
+          };
+        },
       },
     };
 
@@ -3023,6 +3041,34 @@ describe('tools', () => {
         },
       ],
     });
+
+    const { result: health } = await callTool({
+      name: 'get_advisors',
+      arguments: {
+        project_id: project.id,
+        type: 'health',
+      },
+    });
+
+    expect(health).toEqual({
+      lints: [
+        {
+          name: 'project_not_active',
+          title: 'Project Not Active',
+          level: 'INFO',
+          facing: 'EXTERNAL',
+          categories: ['HEALTH'],
+          description: 'The project is inactive.',
+          remediation: 'https://supabase.com/docs/guides/platform/health',
+          count: 1,
+          findings: [
+            {
+              detail: 'Health checks cannot run while the project is inactive.',
+            },
+          ],
+        },
+      ],
+    });
   });
 
   test('get performance advisors', async () => {
@@ -3050,6 +3096,51 @@ describe('tools', () => {
     });
 
     expect(result).toEqual({ lints: [] });
+  });
+
+  test('get health advisors', async () => {
+    const { callTool } = await setup();
+
+    const org = await createOrganization({
+      name: 'My Org',
+      plan: 'free',
+      allowed_release_channels: ['ga'],
+    });
+
+    const project = await createProject({
+      name: 'Project 1',
+      region: 'us-east-1',
+      organization_id: org.id,
+    });
+    project.status = 'ACTIVE_HEALTHY';
+
+    const { result } = await callTool({
+      name: 'get_advisors',
+      arguments: {
+        project_id: project.id,
+        type: 'health',
+      },
+    });
+
+    expect(result).toEqual({
+      lints: [
+        {
+          name: 'project_not_active',
+          title: 'Project Not Active',
+          level: 'INFO',
+          facing: 'EXTERNAL',
+          categories: ['HEALTH'],
+          description: 'The project is inactive.',
+          remediation: 'https://supabase.com/docs/guides/platform/health',
+          count: 1,
+          findings: [
+            {
+              detail: 'Health checks cannot run while the project is inactive.',
+            },
+          ],
+        },
+      ],
+    });
   });
 
   test('get logs for invalid service type', async () => {
@@ -5326,6 +5417,9 @@ describe('feature groups', () => {
         getPerformanceAdvisors() {
           throw new Error('Not implemented');
         },
+        getHealthAdvisors() {
+          throw new Error('Not implemented');
+        },
       },
     };
 
@@ -5364,6 +5458,9 @@ describe('feature groups', () => {
         getPerformanceAdvisors() {
           throw new Error('Not implemented');
         },
+        getHealthAdvisors() {
+          throw new Error('Not implemented');
+        },
       },
     };
 
@@ -5397,6 +5494,9 @@ describe('feature groups', () => {
           throw new Error('Not implemented');
         },
         getPerformanceAdvisors() {
+          throw new Error('Not implemented');
+        },
+        getHealthAdvisors() {
           throw new Error('Not implemented');
         },
       },

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -120,7 +120,7 @@ const queryLogsOutputSchema = z.object({
 const getAdvisorsInputSchema = z.object({
   project_id: z.string(),
   type: z
-    .enum(['security', 'performance'])
+    .enum(['security', 'performance', 'health'])
     .describe('The type of advisors to fetch'),
 });
 
@@ -353,6 +353,9 @@ export function getDebuggingTools({
             break;
           case 'performance':
             result = await debugging.getPerformanceAdvisors(project_id);
+            break;
+          case 'health':
+            result = await debugging.getHealthAdvisors(project_id);
             break;
           default:
             throw new Error(`Unknown advisor type: ${type}`);

--- a/packages/mcp-server-supabase/src/tools/debugging-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/debugging-tools.ts
@@ -243,7 +243,7 @@ export const debuggingToolDefs = {
   },
   get_advisors: {
     description:
-      "Gets a list of advisory notices for the Supabase project. Use this to check for security vulnerabilities or performance improvements. Include the remediation URL as a clickable link so that the user can reference the issue themselves. It's recommended to run this tool regularly, especially after making DDL changes to the database since it will catch things like missing RLS policies.",
+      "Gets a list of advisory notices for the Supabase project. Use this to check for security vulnerabilities, performance improvements, or health issues. Include the remediation URL as a clickable link so that the user can reference the issue themselves. It's recommended to run this tool regularly, especially after making DDL changes to the database since it will catch things like missing RLS policies.",
     parameters: getAdvisorsInputSchema,
     outputSchema: getAdvisorsOutputSchema,
     annotations: {

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -614,7 +614,7 @@ export const mockManagementApi = [
 
   http.get<{ projectId: string }>(
     `${API_URL}/platform/projects/:projectId/run-lints`,
-    async ({ params }) => {
+    async ({ params, request }) => {
       const project = mockProjects.get(params.projectId);
       if (!project) {
         return HttpResponse.json(
@@ -622,6 +622,10 @@ export const mockManagementApi = [
           { status: 404 }
         );
       }
+
+      expect(request.headers.get('user-agent')).toBe(
+        `${MCP_SERVER_NAME}/${MCP_SERVER_VERSION} (${MCP_CLIENT_NAME}/${MCP_CLIENT_VERSION})`
+      );
 
       return HttpResponse.json([
         {
@@ -634,6 +638,17 @@ export const mockManagementApi = [
           detail: 'Health checks cannot run while the project is inactive.',
           remediation: 'https://supabase.com/docs/guides/platform/health',
           cache_key: 'project_not_active',
+        },
+        {
+          name: 'advisor_check_unavailable',
+          title: 'Advisor Check Unavailable',
+          level: 'WARN',
+          facing: 'EXTERNAL',
+          categories: ['HEALTH'],
+          description: 'The health advisor check is unavailable.',
+          detail: 'Database telemetry is temporarily unavailable.',
+          remediation: 'https://supabase.com/docs/guides/platform/health',
+          cache_key: 'advisor_check_unavailable',
         },
         {
           name: 'unused_index',

--- a/packages/mcp-server-supabase/test/mocks.ts
+++ b/packages/mcp-server-supabase/test/mocks.ts
@@ -612,6 +612,45 @@ export const mockManagementApi = [
     }
   ),
 
+  http.get<{ projectId: string }>(
+    `${API_URL}/platform/projects/:projectId/run-lints`,
+    async ({ params }) => {
+      const project = mockProjects.get(params.projectId);
+      if (!project) {
+        return HttpResponse.json(
+          { message: 'Project not found' },
+          { status: 404 }
+        );
+      }
+
+      return HttpResponse.json([
+        {
+          name: 'project_not_active',
+          title: 'Project Not Active',
+          level: 'INFO',
+          facing: 'EXTERNAL',
+          categories: ['HEALTH'],
+          description: 'The project is inactive.',
+          detail: 'Health checks cannot run while the project is inactive.',
+          remediation: 'https://supabase.com/docs/guides/platform/health',
+          cache_key: 'project_not_active',
+        },
+        {
+          name: 'unused_index',
+          title: 'Unused Index',
+          level: 'INFO',
+          facing: 'EXTERNAL',
+          categories: ['PERFORMANCE'],
+          description: 'The index is unused.',
+          detail: 'Index `idx_unused` has not been used.',
+          remediation:
+            'https://supabase.com/docs/guides/database/database-linter',
+          cache_key: 'unused_index_idx_unused',
+        },
+      ]);
+    }
+  ),
+
   /**
    * Create a new branch for a project
    */


### PR DESCRIPTION
## Problem

The existing `get_advisors` tool exposes Security and Performance findings but not Health Advisor findings.

## Fix

Add `health` as an advisor type and retrieve lints from the typed Platform API client introduced in the base PR. Return only Health-category lints while preserving inactive and unavailable-check findings.

## How to test

- Run `CI=1 pnpm --filter @supabase/mcp-server-supabase test -- --run src/platform-api/index.test.ts`
- Expected result: the typed Platform API client test passes.
- Run the server test suite in CI.
- Expected result: Health Advisor lints are returned, Performance lints are excluded, and unavailable/inactive Health results are preserved.