### PR TITLE
Fix scoped legacy branch cost confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ for (const step of await result.steps) {
 `createToolSchemas()` accepts similar filtering options as the MCP server's URL parameters:
 
 - `features`: Restrict to specific [feature groups](https://supabase.com/mcp#configuration-options) (e.g. `['database', 'docs']`). Defaults to all default feature groups.
-- `projectScoped`: When `true`, omits `project_id` from tool input schemas and excludes account-level tools — use when connecting to a server configured with `project_ref`. Defaults to `false`.
+- `projectScoped`: When `true`, omits `project_id` from tool input schemas and excludes account-level operations; writable branching retains branch-only cost quotation and confirmation schemas — use when connecting to a server configured with `project_ref`. Defaults to `false`.
 - `readOnly`: When `true`, excludes mutating tools — use when connecting to a server configured with `read_only=true`. Defaults to `false`.
 
 ```ts

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -156,6 +156,7 @@ type ModernSetupOptions = {
   clientCapabilities?: ClientCapabilities;
   readOnly?: boolean;
   projectId?: string;
+  features?: string[];
   /**
    * Registers an auto-fulfilling `elicitation/create` handler that always
    * answers with this action, driven via `client.callTool`. Omit for manual
@@ -191,6 +192,7 @@ async function setupModern(options: ModernSetupOptions = {}) {
   const {
     readOnly,
     projectId,
+    features,
     elicitationAction,
     costConfirmation = COST_CONFIRMATION,
     clientCapabilities = {},
@@ -214,6 +216,7 @@ async function setupModern(options: ModernSetupOptions = {}) {
     platform,
     projectId,
     readOnly,
+    features,
     costConfirmation,
   });
 
@@ -3882,7 +3885,7 @@ describe('tools', () => {
       );
     });
 
-    test('create_branch advertises confirm_cost_id as optional when cost confirmation is configured', async () => {
+    test('create_branch requires confirm_cost_id for configured legacy fallback', async () => {
       const { client } = await setup({
         features: ['branching'],
         costConfirmation: COST_CONFIRMATION,
@@ -3893,62 +3896,127 @@ describe('tools', () => {
         (tool) => tool.name === 'create_branch'
       );
 
-      expect(createBranchTool?.inputSchema.required).not.toContain(
+      expect(createBranchTool?.inputSchema.required).toContain(
         'confirm_cost_id'
       );
     });
 
-    test('capability-free client still succeeds via get_cost -> confirm_cost -> create_branch', async () => {
-      const { callTool } = await setup({
-        features: ['account', 'branching'],
-        costConfirmation: COST_CONFIRMATION,
-      });
+    test.each([false, true])(
+      'branching-only legacy quote -> confirm -> create (scoped: %s)',
+      async (scoped) => {
+        const org = await createOrganization({
+          name: 'My Org',
+          plan: 'free',
+          allowed_release_channels: ['ga'],
+        });
+        const project = await createProject({
+          name: 'Project 1',
+          region: 'us-east-1',
+          organization_id: org.id,
+        });
+        project.status = 'ACTIVE_HEALTHY';
+        const { callTool } = await setup({
+          features: ['branching'],
+          projectId: scoped ? project.id : undefined,
+          costConfirmation: COST_CONFIRMATION,
+        });
+        const requests: string[] = [];
+        const onRequest = ({ request }: { request: Request }) => {
+          if (request.url.startsWith(`${API_URL}/v1/`)) {
+            requests.push(`${request.method} ${request.url}`);
+          }
+        };
+        mockServer!.events.on('request:start', onRequest);
+        try {
+          const cost = await callTool({
+            name: 'get_cost',
+            arguments: { type: 'branch' },
+          });
+          expect(cost).toEqual({
+            type: 'branch',
+            amount: BRANCH_COST_HOURLY,
+            recurrence: 'hourly',
+          });
+          const confirmation = await callTool({
+            name: 'confirm_cost',
+            arguments: cost,
+          });
+          expect(requests).toEqual([]);
+          const branch = await callTool({
+            name: 'create_branch',
+            arguments: {
+              ...(scoped ? {} : { project_id: project.id }),
+              name: 'test-branch',
+              confirm_cost_id: confirmation.confirmation_id,
+            },
+          });
+          expect(branch).toMatchObject({
+            name: 'test-branch',
+            parent_project_ref: project.id,
+          });
+          expect(
+            Array.from(mockBranches.values()).filter(
+              (branch) => !branch.is_default
+            )
+          ).toMatchObject([
+            { name: 'test-branch', parent_project_ref: project.id },
+          ]);
+          expect(requests).toEqual([
+            `POST ${API_URL}/v1/projects/${project.id}/branches`,
+          ]);
+        } finally {
+          mockServer!.events.removeListener('request:start', onRequest);
+        }
+      }
+    );
 
-      const org = await createOrganization({
-        name: 'My Org',
-        plan: 'free',
-        allowed_release_channels: ['ga'],
-      });
-
-      const project = await createProject({
-        name: 'Project 1',
-        region: 'us-east-1',
-        organization_id: org.id,
-      });
-      project.status = 'ACTIVE_HEALTHY';
-
-      const confirm_cost_id_result = await callTool({
-        name: 'confirm_cost',
-        arguments: {
-          type: 'branch',
-          recurrence: 'hourly',
-          amount: BRANCH_COST_HOURLY,
-        },
-      });
-
-      const branchName = 'test-branch';
-      const result = await callTool({
+    test.each([
+      { name: 'create_branch', arguments: { name: 'test-branch' } },
+      {
         name: 'create_branch',
-        arguments: {
-          project_id: project.id,
-          name: branchName,
-          confirm_cost_id: confirm_cost_id_result.confirmation_id,
-        },
-      });
-
-      expect(result).toMatchObject({
-        name: branchName,
-        parent_project_ref: project.id,
-      });
-      // Creating a project's first branch also mints a same-named
-      // `is_default` mock branch representing the parent project itself -
-      // filter it out to count only the branch this call created.
-      expect(
-        Array.from(mockBranches.values()).filter(
-          (branch) => branch.name === branchName && !branch.is_default
-        )
-      ).toHaveLength(1);
-    });
+        arguments: { name: 'test-branch', confirm_cost_id: 'wrong-cost-id' },
+      },
+      { name: 'get_cost', arguments: { type: 'project' } },
+      {
+        name: 'confirm_cost',
+        arguments: { type: 'project', amount: 0, recurrence: 'monthly' },
+      },
+    ])(
+      'branch-only fallback rejects unsupported or unconfirmed calls: %j',
+      async (params) => {
+        const org = await createOrganization({
+          name: 'My Org',
+          plan: 'free',
+          allowed_release_channels: ['ga'],
+        });
+        const project = await createProject({
+          name: 'Project 1',
+          region: 'us-east-1',
+          organization_id: org.id,
+        });
+        project.status = 'ACTIVE_HEALTHY';
+        const { client } = await setup({
+          features: ['branching'],
+          projectId: project.id,
+          costConfirmation: COST_CONFIRMATION,
+        });
+        const requests: string[] = [];
+        const onRequest = ({ request }: { request: Request }) => {
+          if (request.url.startsWith(`${API_URL}/v1/`)) {
+            requests.push(`${request.method} ${request.url}`);
+          }
+        };
+        mockServer!.events.on('request:start', onRequest);
+        try {
+          const result = await client.callTool(params);
+          expect(result.isError).toBe(true);
+          expect(requests).toEqual([]);
+          expect(mockBranches.size).toBe(0);
+        } finally {
+          mockServer!.events.removeListener('request:start', onRequest);
+        }
+      }
+    );
 
     test('form-capable client: accept creates the branch exactly once', async () => {
       const { client } = await setupModern({
@@ -4292,55 +4360,111 @@ describe('tools', () => {
       expect(mockBranches.size).toBe(0);
     });
 
-    test('project-scoped server signs and uses the configured project', async () => {
-      const org = await createOrganization({
-        name: 'My Org',
-        plan: 'free',
-        allowed_release_channels: ['ga'],
-      });
-
-      const project = await createProject({
-        name: 'Project 1',
-        region: 'us-east-1',
-        organization_id: org.id,
-      });
-      project.status = 'ACTIVE_HEALTHY';
-
-      const { client } = await setupModern({
-        clientCapabilities: FORM_CAPABLE,
-        projectId: project.id,
-        elicitationAction: 'accept',
-      });
-
-      const { tools } = await client.listTools();
-      const createBranchTool = tools.find(
-        (tool) => tool.name === 'create_branch'
-      );
-      expect(
-        Object.keys(createBranchTool?.inputSchema.properties ?? {})
-      ).not.toContain('project_id');
-
-      const result = await client.callTool({
-        name: 'create_branch',
-        arguments: { name: 'test-branch' },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const [content] = result.content;
-      if (content?.type !== 'text') {
-        throw new Error('expected text content');
+    test.each(['accept', 'cancel'] as const)(
+      'scoped branching-only form %s preserves the configured project',
+      async (action) => {
+        const org = await createOrganization({
+          name: 'My Org',
+          plan: 'free',
+          allowed_release_channels: ['ga'],
+        });
+        const project = await createProject({
+          name: 'Project 1',
+          region: 'us-east-1',
+          organization_id: org.id,
+        });
+        project.status = 'ACTIVE_HEALTHY';
+        const { client } = await setupModern({
+          clientCapabilities: FORM_CAPABLE,
+          projectId: project.id,
+          features: ['branching'],
+        });
+        const { tools } = await client.listTools();
+        const createBranchTool = tools.find(
+          (tool) => tool.name === 'create_branch'
+        );
+        expect(createBranchTool).toBeDefined();
+        expect(createBranchTool?.inputSchema.properties).not.toHaveProperty(
+          'project_id'
+        );
+        expect(createBranchTool?.inputSchema.properties).not.toHaveProperty(
+          'confirm_cost_id'
+        );
+        expect(tools.map((tool) => tool.name)).not.toContain('get_cost');
+        expect(tools.map((tool) => tool.name)).not.toContain('confirm_cost');
+        const requests: string[] = [];
+        const onRequest = ({ request }: { request: Request }) => {
+          if (request.url.startsWith(`${API_URL}/v1/`)) {
+            requests.push(`${request.method} ${request.url}`);
+          }
+        };
+        mockServer!.events.on('request:start', onRequest);
+        try {
+          const args = { name: 'test-branch' };
+          const first = (await client.request(
+            {
+              method: 'tools/call',
+              params: { name: 'create_branch', arguments: args },
+            },
+            { allowInputRequired: true }
+          )) as CallToolResult | InputRequiredResult;
+          if (!isInputRequiredResult(first)) {
+            throw new Error('expected an input_required result');
+          }
+          expect(first.inputRequests?.confirm_cost).toMatchObject({
+            method: 'elicitation/create',
+            params: { mode: 'form' },
+          });
+          expect(requests).toEqual([]);
+          expect(mockBranches.size).toBe(0);
+          const result = (await client.request(
+            {
+              method: 'tools/call',
+              params: {
+                name: 'create_branch',
+                arguments: args,
+                inputResponses: {
+                  confirm_cost:
+                    action === 'accept' ? { action, content: {} } : { action },
+                },
+                requestState: first.requestState,
+              },
+            },
+            { allowInputRequired: true }
+          )) as CallToolResult | InputRequiredResult;
+          if (isInputRequiredResult(result)) {
+            throw new Error('expected a CallToolResult');
+          }
+          expect(result.isError).toBeFalsy();
+          if (action === 'cancel') {
+            expect(result.structuredContent).toEqual({ status: 'cancelled' });
+            expect(requests).toEqual([]);
+            expect(mockBranches.size).toBe(0);
+          } else {
+            const [content] = result.content;
+            if (content?.type !== 'text') {
+              throw new Error('expected text content');
+            }
+            expect(JSON.parse(content.text)).toMatchObject({
+              name: 'test-branch',
+              parent_project_ref: project.id,
+            });
+            expect(
+              Array.from(mockBranches.values()).filter(
+                (branch) => !branch.is_default
+              )
+            ).toMatchObject([
+              { name: 'test-branch', parent_project_ref: project.id },
+            ]);
+            expect(requests).toEqual([
+              `POST ${API_URL}/v1/projects/${project.id}/branches`,
+            ]);
+          }
+        } finally {
+          mockServer!.events.removeListener('request:start', onRequest);
+        }
       }
-      const branch = JSON.parse(content.text);
-      expect(branch).toMatchObject({
-        name: 'test-branch',
-        parent_project_ref: project.id,
-      });
-      expect(
-        Array.from(mockBranches.values()).filter(
-          (branch) => branch.name === 'test-branch' && !branch.is_default
-        )
-      ).toHaveLength(1);
-    });
+    );
 
     test('rejects a requestState minted by create_project', async () => {
       const { client } = await setupModern({
@@ -5454,22 +5578,121 @@ describe('feature groups', () => {
     ]);
   });
 
-  test('branching tools', async () => {
+  test.each([
+    { projectId: undefined, costConfirmation: undefined },
+    { projectId: 'scoped-project', costConfirmation: undefined },
+    { projectId: undefined, costConfirmation: COST_CONFIRMATION },
+    { projectId: 'scoped-project', costConfirmation: COST_CONFIRMATION },
+  ])('branching tools include fallback helpers: %j', async (options) => {
     const { client } = await setup({
+      ...options,
       features: ['branching'],
     });
-
     const { tools } = await client.listTools();
-    const toolNames = tools.map((tool) => tool.name);
+    expect(tools.map((tool) => tool.name).sort()).toEqual(
+      [
+        'create_branch',
+        'list_branches',
+        'delete_branch',
+        'merge_branch',
+        'reset_branch',
+        'rebase_branch',
+        'get_cost',
+        'confirm_cost',
+      ].sort()
+    );
+    expect(
+      tools.find((tool) => tool.name === 'get_cost')?.inputSchema.properties
+    ).not.toHaveProperty('organization_id');
+  });
 
-    expect(toolNames).toEqual([
-      'create_branch',
-      'list_branches',
-      'delete_branch',
-      'merge_branch',
-      'reset_branch',
-      'rebase_branch',
+  test.each([
+    { features: ['database'], readOnly: false },
+    { features: ['branching'], readOnly: true },
+  ])(
+    'no branch-only helpers without writable branching: %j',
+    async (options) => {
+      const { client } = await setup({
+        ...options,
+        projectId: 'scoped-project',
+        costConfirmation: COST_CONFIRMATION,
+      });
+      const { tools } = await client.listTools();
+      const names = tools.map((tool) => tool.name);
+      expect(names).not.toContain('create_branch');
+      expect(names).not.toContain('get_cost');
+      expect(names).not.toContain('confirm_cost');
+    }
+  );
+
+  test.each([
+    { enabledTools: ['create_project'] as const, fallback: true },
+    { enabledTools: ['create_branch'] as const, fallback: false },
+  ])(
+    'scoped modern branch fallback follows branch enablement: %j',
+    async ({ enabledTools, fallback }) => {
+      const { client } = await setupModern({
+        projectId: 'scoped-project',
+        features: ['branching'],
+        clientCapabilities: FORM_CAPABLE,
+        costConfirmation: {
+          ...COST_CONFIRMATION,
+          enabledTools: [...enabledTools],
+        },
+      });
+      const { tools } = await client.listTools();
+      const names = tools.map((tool) => tool.name);
+      for (const name of ['get_cost', 'confirm_cost']) {
+        expect(names.includes(name)).toBe(fallback);
+      }
+      const branchTool = tools.find((tool) => tool.name === 'create_branch');
+      expect(branchTool).toBeDefined();
+      if (fallback) {
+        expect(branchTool?.inputSchema.required).toContain('confirm_cost_id');
+      } else {
+        expect(branchTool?.inputSchema.properties).not.toHaveProperty(
+          'confirm_cost_id'
+        );
+      }
+    }
+  );
+
+  test('scoped modern client without forms retains branch fallback helpers', async () => {
+    const { client } = await setupModern({
+      projectId: 'scoped-project',
+      features: ['branching'],
+    });
+    const { tools } = await client.listTools();
+    const names = tools.map((tool) => tool.name);
+    expect(names).toContain('get_cost');
+    expect(names).toContain('confirm_cost');
+    expect(
+      tools.find((tool) => tool.name === 'create_branch')?.inputSchema.required
+    ).toContain('confirm_cost_id');
+  });
+
+  test('account cost helper schemas retain project and branch contracts', async () => {
+    const { client } = await setup({
+      features: ['account', 'branching'],
+      costConfirmation: COST_CONFIRMATION,
+    });
+    const { tools } = await client.listTools();
+    const getCost = tools.find((tool) => tool.name === 'get_cost');
+    const confirmCost = tools.find((tool) => tool.name === 'confirm_cost');
+    expect(getCost?.inputSchema.required?.slice().sort()).toEqual([
+      'organization_id',
+      'type',
     ]);
+    expect(confirmCost?.inputSchema.required?.slice().sort()).toEqual([
+      'amount',
+      'recurrence',
+      'type',
+    ]);
+    for (const tool of [getCost, confirmCost]) {
+      expect(tool?.inputSchema.properties?.type).toMatchObject({
+        enum: ['project', 'branch'],
+      });
+    }
   });
 
   test('storage tools', async () => {
@@ -5591,14 +5814,14 @@ describe('project scoped tools', () => {
       'get_organization',
       'list_projects',
       'get_project',
-      'get_cost',
-      'confirm_cost',
       'create_project',
       'pause_project',
       'restore_project',
     ];
 
     const toolNames = result.tools.map((tool) => tool.name);
+    expect(toolNames).toContain('get_cost');
+    expect(toolNames).toContain('confirm_cost');
 
     for (const accountLevelToolName of accountLevelToolNames) {
       expect(

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -8,7 +8,10 @@ import packageJson from '../package.json' with { type: 'json' };
 import { createContentApiClient } from './content-api/index.js';
 import type { SupabasePlatform } from './platform/types.js';
 import { getAccountTools } from './tools/account-tools.js';
-import { getBranchingTools } from './tools/branching-tools.js';
+import {
+  getBranchCostTools,
+  getBranchingTools,
+} from './tools/branching-tools.js';
 import {
   type CostConfirmationState,
   isFormCapable,
@@ -20,7 +23,7 @@ import { getDocsTools } from './tools/docs-tools.js';
 import { getEdgeFunctionTools } from './tools/edge-function-tools.js';
 import { getStorageTools } from './tools/storage-tools.js';
 import { writeToolSet } from './tools/tool-schemas.js';
-import type { FeatureGroup } from './types.js';
+import { PLATFORM_INDEPENDENT_FEATURES, type FeatureGroup } from './types.js';
 import { parseFeatureGroups } from './util.js';
 import { z } from 'zod/v4';
 
@@ -89,8 +92,6 @@ const DEFAULT_FEATURES: FeatureGroup[] = [
   'functions',
   'branching',
 ];
-
-export const PLATFORM_INDEPENDENT_FEATURES: FeatureGroup[] = ['docs'];
 
 export const instructions = `
 Here are guidelines for using Supabase tools effectively:
@@ -230,6 +231,14 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
         );
       }
 
+      const branchCostConfirmation =
+        costConfirmationCodec &&
+        costConfirmation?.enabledTools.includes('create_branch') &&
+        ctx &&
+        isFormCapable(ctx)
+          ? { codec: costConfirmationCodec }
+          : undefined;
+
       if (branching && enabledFeatures.has('branching')) {
         Object.assign(
           tools,
@@ -237,11 +246,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
             branching,
             projectId,
             readOnly,
-            costConfirmation:
-              costConfirmationCodec &&
-              costConfirmation?.enabledTools.includes('create_branch')
-                ? { codec: costConfirmationCodec }
-                : undefined,
+            costConfirmation: branchCostConfirmation,
           })
         );
       }
@@ -296,6 +301,19 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
               }
             : { ...tool, hidden: true };
         }
+      }
+
+      // Install branch-only fallbacks after account cost pruning so their
+      // supported cost type cannot be widened to project.
+      if (
+        branching &&
+        enabledFeatures.has('branching') &&
+        !readOnly &&
+        !branchCostConfirmation &&
+        !tools.get_cost &&
+        !tools.confirm_cost
+      ) {
+        Object.assign(tools, getBranchCostTools());
       }
 
       return tools;

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -10,6 +10,7 @@ import type { BranchingOperations } from '../platform/types.js';
 import { branchSchema } from '../platform/types.js';
 import { getBranchCost } from '../pricing.js';
 import { hashObject } from '../util.js';
+import { accountToolDefs } from './account-tools.js';
 import {
   actionOnlyElicitationSchema,
   isFormCapable,
@@ -179,6 +180,45 @@ export const branchingToolDefs = {
     },
   },
 } as const satisfies ToolDefs;
+
+const branchCostTypeSchema = z.enum(['branch']);
+
+export const branchCostToolDefs = {
+  get_cost: {
+    ...accountToolDefs.get_cost,
+    description:
+      'Gets the cost of creating a new branch. Always repeat the cost to the user and confirm their understanding before proceeding.',
+    parameters: accountToolDefs.get_cost.parameters
+      .pick({ type: true })
+      .extend({ type: branchCostTypeSchema }),
+    outputSchema: accountToolDefs.get_cost.outputSchema.extend({
+      type: branchCostTypeSchema,
+    }),
+  },
+  confirm_cost: {
+    ...accountToolDefs.confirm_cost,
+    description:
+      'Ask the user to confirm their understanding of the cost of creating a new branch. Call `get_cost` first. Returns a unique ID for this confirmation which should be passed to `create_branch`.',
+    parameters: accountToolDefs.confirm_cost.parameters.extend({
+      type: branchCostTypeSchema,
+    }),
+  },
+} as const satisfies ToolDefs;
+
+export function getBranchCostTools() {
+  return {
+    get_cost: tool({
+      ...branchCostToolDefs.get_cost,
+      execute: async () => getBranchCost(),
+    }),
+    confirm_cost: tool({
+      ...branchCostToolDefs.confirm_cost,
+      execute: async (cost) => ({
+        confirmation_id: await hashObject(cost),
+      }),
+    }),
+  };
+}
 
 export function getBranchingTools({
   branching,

--- a/packages/mcp-server-supabase/src/tools/tool-schemas.test.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.test.ts
@@ -128,24 +128,262 @@ describe('createToolSchemas', () => {
       expect(shape).not.toHaveProperty('project_id');
       expect(shape).toHaveProperty('query');
     });
+  });
 
-    test('type reflects project_id omission', () => {
-      const schemas = createToolSchemas({ projectScoped: true });
-
-      // The input schema type should NOT include project_id
-      type ExecuteSqlInput = (typeof schemas)['execute_sql']['inputSchema'];
-      expectTypeOf<ExecuteSqlInput>().not.toHaveProperty('project_id');
+  describe('branch-only cost helpers', () => {
+    test('boolean project scope retains account and branch-only quote alternatives', () => {
+      const schemas = createToolSchemas({
+        features: ['account', 'branching'],
+        projectScoped: false as boolean,
+      });
+      const scopedSchemas = createToolSchemas({
+        features: ['account', 'branching'],
+        projectScoped: true,
+      });
+      expectTypeOf<
+        z.input<typeof schemas.get_cost.inputSchema>
+      >().toEqualTypeOf<
+        | { type: 'project' | 'branch'; organization_id: string }
+        | { type: 'branch' }
+      >();
+      expectTypeOf<typeof schemas.get_cost.outputSchema>().toEqualTypeOf<
+        | typeof supabaseMcpToolSchemas.get_cost.outputSchema
+        | typeof scopedSchemas.get_cost.outputSchema
+      >();
+      expectTypeOf<
+        z.output<typeof schemas.get_cost.outputSchema>
+      >().toEqualTypeOf<
+        | {
+            type: 'project' | 'branch';
+            amount: number;
+            recurrence: 'hourly' | 'monthly';
+          }
+        | {
+            type: 'branch';
+            amount: number;
+            recurrence: 'hourly' | 'monthly';
+          }
+      >();
+      const input = { type: 'project', organization_id: 'fixture-org' };
+      expect(schemas.get_cost.inputSchema.parse(input)).toEqual(input);
+      expect(
+        schemas.get_cost.inputSchema.safeParse({ type: 'branch' }).success
+      ).toBe(false);
     });
 
-    test('non-project-id tools retain original schemas', () => {
-      const schemas = createToolSchemas({ projectScoped: true });
-
-      // search_docs has no project_id - should use original schema
-      expect(schemas.search_docs).toBe(supabaseMcpToolSchemas.search_docs);
-
-      // delete_branch uses branch_id, not project_id - should use original schema
-      expect(schemas.delete_branch).toBe(supabaseMcpToolSchemas.delete_branch);
+    test('boolean read-only retains both helper-present and helper-absent maps', () => {
+      const schemas = createToolSchemas({
+        features: ['branching'],
+        readOnly: false as boolean,
+      });
+      const writableSchemas = createToolSchemas({ features: ['branching'] });
+      const readOnlySchemas = createToolSchemas({
+        features: ['branching'],
+        readOnly: true,
+      });
+      expectTypeOf(schemas).toEqualTypeOf<
+        typeof writableSchemas | typeof readOnlySchemas
+      >();
+      expectTypeOf<
+        Extract<typeof schemas, { get_cost: unknown }>
+      >().toEqualTypeOf<typeof writableSchemas>();
+      expectTypeOf<
+        Exclude<typeof schemas, { get_cost: unknown }>
+      >().toEqualTypeOf<typeof readOnlySchemas>();
+      expect(schemas).toHaveProperty('get_cost');
+      expect(schemas).toHaveProperty('confirm_cost');
     });
+
+    test.each([
+      {
+        name: 'scoped defaults',
+        create: () => createToolSchemas({ projectScoped: true }),
+      },
+      {
+        name: 'scoped branching-only',
+        create: () =>
+          createToolSchemas({ features: ['branching'], projectScoped: true }),
+      },
+      {
+        name: 'unscoped branching-only',
+        create: () => createToolSchemas({ features: ['branching'] }),
+      },
+    ])(
+      '$name exposes branch-only cost input and output types',
+      ({ create }) => {
+        const schemas = create();
+        expectTypeOf(schemas).toHaveProperty('get_cost');
+        expectTypeOf(schemas).toHaveProperty('confirm_cost');
+        expectTypeOf<
+          z.input<typeof schemas.get_cost.inputSchema>
+        >().toEqualTypeOf<{
+          type: 'branch';
+        }>();
+        expectTypeOf<
+          z.input<typeof schemas.confirm_cost.inputSchema>
+        >().toEqualTypeOf<{
+          type: 'branch';
+          amount: number;
+          recurrence: 'hourly' | 'monthly';
+        }>();
+        expectTypeOf<
+          z.output<typeof schemas.get_cost.outputSchema>
+        >().toEqualTypeOf<{
+          type: 'branch';
+          amount: number;
+          recurrence: 'hourly' | 'monthly';
+        }>();
+        expectTypeOf<
+          z.output<typeof schemas.confirm_cost.outputSchema>
+        >().toEqualTypeOf<{ confirmation_id: string }>();
+
+        const quote = { type: 'branch', amount: 0.01344, recurrence: 'hourly' };
+        expect(schemas.get_cost.inputSchema.parse({ type: 'branch' })).toEqual({
+          type: 'branch',
+        });
+        expect(schemas.get_cost.inputSchema.shape).not.toHaveProperty(
+          'organization_id'
+        );
+        expect(
+          schemas.get_cost.inputSchema.safeParse({ type: 'project' }).success
+        ).toBe(false);
+        expect(schemas.confirm_cost.inputSchema.parse(quote)).toEqual(quote);
+        expect(
+          schemas.confirm_cost.inputSchema.safeParse({
+            ...quote,
+            type: 'project',
+          }).success
+        ).toBe(false);
+        expect(
+          schemas.confirm_cost.inputSchema.safeParse({
+            type: 'branch',
+            recurrence: 'hourly',
+          }).success
+        ).toBe(false);
+        expect(
+          schemas.confirm_cost.inputSchema.safeParse({
+            type: 'branch',
+            amount: quote.amount,
+          }).success
+        ).toBe(false);
+        expect(schemas.get_cost.outputSchema.parse(quote)).toEqual(quote);
+        expect(
+          schemas.get_cost.outputSchema.safeParse({
+            ...quote,
+            type: 'project',
+          }).success
+        ).toBe(false);
+        expect(
+          schemas.confirm_cost.outputSchema.parse({
+            confirmation_id: 'cost-id',
+          })
+        ).toEqual({ confirmation_id: 'cost-id' });
+      }
+    );
+
+    test.each([
+      {
+        name: 'read-only scoped defaults',
+        create: () =>
+          createToolSchemas({ projectScoped: true, readOnly: true }),
+      },
+      {
+        name: 'read-only scoped branching',
+        create: () =>
+          createToolSchemas({
+            features: ['branching'],
+            projectScoped: true,
+            readOnly: true,
+          }),
+      },
+      {
+        name: 'read-only unscoped branching',
+        create: () =>
+          createToolSchemas({ features: ['branching'], readOnly: true }),
+      },
+      {
+        name: 'scoped account without branching',
+        create: () =>
+          createToolSchemas({ features: ['account'], projectScoped: true }),
+      },
+      {
+        name: 'unscoped without account or branching',
+        create: () => createToolSchemas({ features: ['database'] }),
+      },
+    ])(
+      '$name omits branch-only helpers from runtime and inferred keys',
+      ({ create }) => {
+        const schemas = create();
+        expect(schemas).not.toHaveProperty('get_cost');
+        expect(schemas).not.toHaveProperty('confirm_cost');
+        expectTypeOf(schemas).not.toHaveProperty('get_cost');
+        expectTypeOf(schemas).not.toHaveProperty('confirm_cost');
+        // Check every factory's return type, not only the union's common keys.
+        expectTypeOf<
+          Extract<typeof schemas, { get_cost: unknown }>
+        >().toEqualTypeOf<never>();
+        expectTypeOf<
+          Extract<typeof schemas, { confirm_cost: unknown }>
+        >().toEqualTypeOf<never>();
+      }
+    );
+
+    test.each([
+      {
+        name: 'account only',
+        create: () => createToolSchemas({ features: ['account'] }),
+      },
+      {
+        name: 'account and branching',
+        create: () => createToolSchemas({ features: ['account', 'branching'] }),
+      },
+      {
+        name: 'read-only account and branching',
+        create: () =>
+          createToolSchemas({
+            features: ['account', 'branching'],
+            readOnly: true,
+          }),
+      },
+    ])(
+      '$name preserves account cost schemas and inferred types',
+      ({ create }) => {
+        const schemas = create();
+        expectTypeOf<
+          z.input<typeof schemas.get_cost.inputSchema>
+        >().toEqualTypeOf<{
+          type: 'project' | 'branch';
+          organization_id: string;
+        }>();
+        expectTypeOf<
+          z.input<typeof schemas.confirm_cost.inputSchema>
+        >().toEqualTypeOf<{
+          type: 'project' | 'branch';
+          amount: number;
+          recurrence: 'hourly' | 'monthly';
+        }>();
+        expectTypeOf<
+          z.output<typeof schemas.get_cost.outputSchema>
+        >().toEqualTypeOf<{
+          type: 'project' | 'branch';
+          amount: number;
+          recurrence: 'hourly' | 'monthly';
+        }>();
+        expectTypeOf<
+          z.output<typeof schemas.confirm_cost.outputSchema>
+        >().toEqualTypeOf<{ confirmation_id: string }>();
+        for (const type of ['project', 'branch'] as const) {
+          const input = { type, organization_id: 'fixture-org' };
+          const quote = { type, amount: 1, recurrence: 'monthly' };
+          expect(schemas.get_cost.inputSchema.parse(input)).toEqual(input);
+          expect(schemas.get_cost.inputSchema.safeParse({ type }).success).toBe(
+            false
+          );
+          expect(schemas.confirm_cost.inputSchema.parse(quote)).toEqual(quote);
+          expect(schemas.get_cost.outputSchema.parse(quote)).toEqual(quote);
+        }
+      }
+    );
   });
 
   describe('readOnly', () => {

--- a/packages/mcp-server-supabase/src/tools/tool-schemas.ts
+++ b/packages/mcp-server-supabase/src/tools/tool-schemas.ts
@@ -1,7 +1,7 @@
 import type { z } from 'zod/v4';
 import { CURRENT_FEATURE_GROUPS, type FeatureGroup } from '../types.js';
 import { accountToolDefs } from './account-tools.js';
-import { branchingToolDefs } from './branching-tools.js';
+import { branchCostToolDefs, branchingToolDefs } from './branching-tools.js';
 import { databaseToolDefs } from './database-operation-tools.js';
 import { debuggingToolDefs } from './debugging-tools.js';
 import { developmentToolDefs } from './development-tools.js';
@@ -73,6 +73,8 @@ export const supabaseMcpToolSchemas = {
   ...defsToSchemas(edgeFunctionToolDefs),
   ...defsToSchemas(storageToolDefs),
 } satisfies Record<string, SchemaEntry>;
+
+const branchCostSchemas = defsToSchemas(branchCostToolDefs);
 
 /**
  * Maps each feature group to its tool names.
@@ -184,50 +186,83 @@ type WriteToolName = {
     : never;
 }[keyof AllSchemas];
 
+type BranchCostToolNames<
+  Feature extends FeatureGroup,
+  ProjectScoped extends boolean,
+  ReadOnly extends boolean,
+> = 'branching' extends Feature
+  ? ReadOnly extends true
+    ? never
+    : ProjectScoped extends true
+      ? keyof typeof branchCostSchemas
+      : 'account' extends Feature
+        ? never
+        : keyof typeof branchCostSchemas
+  : never;
+
 /**
  * Computes the set of tool names available for a given configuration.
  *
  * - Resolves feature groups to their tool names
  * - Excludes account tools when project-scoped
  * - Excludes write-only tools when read-only
+ * - Adds branch-only cost helpers for writable branching without account tools
  */
 type AvailableToolNames<
   Feature extends FeatureGroup,
   ProjectScoped extends boolean,
   ReadOnly extends boolean,
-> = Exclude<
-  ToolNameForFeature<Feature>,
-  | (ProjectScoped extends true ? AccountToolName : never)
-  | (ReadOnly extends true ? WriteToolName : never)
->;
+> =
+  | Exclude<
+      ToolNameForFeature<Feature>,
+      | (ProjectScoped extends true ? AccountToolName : never)
+      | (ReadOnly extends true ? WriteToolName : never)
+    >
+  | BranchCostToolNames<Feature, ProjectScoped, ReadOnly>;
 
 /**
  * Computes the tool schemas for a given configuration.
  *
  * When `ProjectScoped` is `true`, tools with `project_id` use the
  * project-scoped override (with `project_id` omitted from the input
- * schema). All other tools use their original schemas.
+ * schema). Branch-only cost helpers use their narrowed schemas when account
+ * tools are unavailable. All other tools use their original schemas.
+ * Distribute over boolean option cases before selecting schemas so unresolved
+ * options retain each possible map. Feature remains the selected feature set.
  */
 type ToolSchemasFor<
   Feature extends FeatureGroup,
   ProjectScoped extends boolean,
   ReadOnly extends boolean,
-> = Pick<
-  ProjectScoped extends true
-    ? Omit<AllSchemas, ProjectScopedToolName> & ProjectScopedSchemas
-    : AllSchemas,
-  AvailableToolNames<Feature, ProjectScoped, ReadOnly> & keyof AllSchemas
->;
+> = ProjectScoped extends boolean
+  ? ReadOnly extends boolean
+    ? {
+        [Name in AvailableToolNames<
+          Feature,
+          ProjectScoped,
+          ReadOnly
+        >]: Name extends BranchCostToolNames<Feature, ProjectScoped, ReadOnly>
+          ? (typeof branchCostSchemas)[Name]
+          : ProjectScoped extends true
+            ? Name extends keyof ProjectScopedSchemas
+              ? ProjectScopedSchemas[Name]
+              : AllSchemas[Name]
+            : AllSchemas[Name];
+      }
+    : never
+  : never;
 
 /**
  * Creates a dynamically scoped tool schema map for use with AI SDK's
  * `mcpClient.tools()`.
  *
- * Mirrors the server's dynamic tool behavior:
+ * Mirrors the server's legacy tool schemas:
  * - `features` controls which tool groups are included
  * - `projectScoped` omits `project_id` from input schemas and excludes
- *   account tools (matching server behavior when `projectId` is set)
- * - `readOnly` excludes mutating tools
+ *   account operations (matching server behavior when `projectId` is set)
+ * - Writable branching retains branch-only cost helpers when account tools
+ *   are unavailable
+ * - `readOnly` excludes mutating tools and branch-only cost helpers
  *
  * @example
  * ```typescript
@@ -273,6 +308,14 @@ export function createToolSchemas<
         result[toolName] = supabaseMcpToolSchemas[toolName];
       }
     }
+  }
+
+  if (
+    enabledFeatures.has('branching') &&
+    !readOnly &&
+    (projectScoped || !enabledFeatures.has('account'))
+  ) {
+    Object.assign(result, branchCostSchemas);
   }
 
   return result as ToolSchemasFor<Features[number], ProjectScoped, ReadOnly>;

--- a/packages/mcp-server-supabase/src/types.ts
+++ b/packages/mcp-server-supabase/src/types.ts
@@ -28,3 +28,5 @@ export const featureGroupSchema = z
   });
 
 export type FeatureGroup = z.infer<typeof featureGroupSchema>;
+
+export const PLATFORM_INDEPENDENT_FEATURES: FeatureGroup[] = ['docs'];

--- a/packages/mcp-server-supabase/src/util.ts
+++ b/packages/mcp-server-supabase/src/util.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod/v4';
 import type { SupabasePlatform } from './platform/types.js';
-import { PLATFORM_INDEPENDENT_FEATURES } from './server.js';
 import {
   currentFeatureGroupSchema,
   featureGroupSchema,
   type FeatureGroup,
+  PLATFORM_INDEPENDENT_FEATURES,
 } from './types.js';
 
 /**


### PR DESCRIPTION
## Why

Scoped legacy clients exposed `create_branch` but lacked the cost helpers needed to obtain its confirmation ID, leaving branch creation blocked.

## What changed

Provides branch-only quote and confirmation helpers, with matching runtime and static schemas, while keeping approval mandatory and creation scoped to the expected project. Legacy/non-inline `confirm_cost_id` metadata changes from optional to required. Modern inline forms and existing account behavior stay unchanged.

## How to test

```sh
CI=true pnpm --filter @supabase/mcp-server-supabase test:unit --run src/server.test.ts -t 'branching-only legacy quote|branch-only fallback rejects'
```

Expect 6 passing selected tests, with others skipped: successful quote→confirm→create creates exactly one fixture branch in the expected project; missing/wrong IDs and project-cost calls make zero requests or branches. This exact filter has not been rerun separately.

Prior compiled checks passed 8 CLI scenarios and 9 static configurations. Those checks were fixture-only, with no real-backend or hosted-UI proof; transport isolation used JS instrumentation, not an OS-wide firewall.

## Trade-offs

Making the existing field required changes client-visible schema metadata, but makes the approval contract explicit. Legacy IDs remain deterministic hashes, not cryptographic proof of consent.
