### PR TITLE
feat: parse SQL before destructive confirmation

### DIFF
--- a/packages/mcp-server-supabase/package.json
+++ b/packages/mcp-server-supabase/package.json
@@ -58,6 +58,7 @@
     "common-tags": "^1.8.2",
     "gqlmin": "^0.3.1",
     "graphql": "^16.11.0",
+    "libpg-query": "18.1.5-lowmem-32.0",
     "openapi-fetch": "^0.13.5"
   },
   "peerDependencies": {

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -9,6 +9,10 @@ import type {
   ClientCapabilities,
   InputRequiredResult,
 } from '@modelcontextprotocol/client';
+import {
+  createRequestStateCodec,
+  type ServerContext,
+} from '@modelcontextprotocol/server';
 import { StreamTransport } from '@supabase/mcp-utils';
 import { codeBlock, stripIndent } from 'common-tags';
 import gqlmin from 'gqlmin';
@@ -44,6 +48,7 @@ import {
   instructions,
   type SupabaseMcpServerOptions,
 } from './server.js';
+import type { ConfirmationState } from './tools/confirmation.js';
 import {
   createToolSchemas,
   supabaseMcpToolSchemas,
@@ -180,6 +185,9 @@ const FORM_CAPABLE: ClientCapabilities = { elicitation: { form: {} } };
 
 // https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
 const MODERN_PROTOCOL_VERSION = '2026-07-28';
+const RESOURCE_EXHAUSTING_SQL = `SELECT ${'('.repeat(10_000)}1${')'.repeat(
+  10_000
+)};`;
 const MCP_ENDPOINT = new URL('https://mcp.test');
 
 /**
@@ -4493,6 +4501,16 @@ describe('tools', () => {
     return project;
   }
 
+  async function mintSqlConfirmationState(state: ConfirmationState) {
+    const codec = createRequestStateCodec<ConfirmationState>({
+      key: COST_CONFIRMATION.requestStateKey,
+      bind: (ctx) => `${ctx.mcpReq.method}:${COST_CONFIRMATION.principal}`,
+    });
+    return codec.mint(state, {
+      mcpReq: { method: 'tools/call' },
+    } as ServerContext);
+  }
+
   test.each([
     [
       'execute_sql',
@@ -4569,6 +4587,126 @@ describe('tools', () => {
       const operation = tool === 'execute_sql' ? executeSql : applyMigration;
       expect(operation).toHaveBeenCalledOnce();
       expect(operation.mock.calls[0]?.[1]).toMatchObject({ query });
+    }
+  );
+
+  test.each(['execute_sql', 'apply_migration'] as const)(
+    '$tool accepts a matching hand-minted destructive confirmation',
+    async (tool) => {
+      const query = 'DROP TABLE films;';
+      const name = 'parser_positive_control';
+      const { client, platform } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
+      const project = await createActiveProject();
+      const executeSql = vi.spyOn(platform.database!, 'executeSql');
+      const applyMigration = vi.spyOn(platform.database!, 'applyMigration');
+      const queryHash = await hashObject({ query });
+      const requestState = await mintSqlConfirmationState(
+        tool === 'execute_sql'
+          ? { tool, project_id: project.id, queryHash }
+          : { tool, project_id: project.id, name, queryHash }
+      );
+      const result = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            name: tool,
+            arguments: {
+              project_id: project.id,
+              query,
+              ...(tool === 'apply_migration' ? { name } : {}),
+            },
+            requestState,
+            inputResponses: {
+              confirm_destructive: { action: 'accept', content: {} },
+            },
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      expect(isInputRequiredResult(result)).toBe(false);
+      const operation = tool === 'execute_sql' ? executeSql : applyMigration;
+      const otherOperation =
+        tool === 'execute_sql' ? applyMigration : executeSql;
+      expect(operation).toHaveBeenCalledOnce();
+      expect(operation.mock.calls[0]?.[1]).toMatchObject({ query });
+      expect(otherOperation).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each(['execute_sql', 'apply_migration'] as const)(
+    '$tool keeps parser resource failures terminal before and after bound acceptance',
+    async (tool) => {
+      expect(Buffer.byteLength(RESOURCE_EXHAUSTING_SQL)).toBe(20_009);
+      const { client, platform } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
+      const project = await createActiveProject();
+      const executeSql = vi.spyOn(platform.database!, 'executeSql');
+      const applyMigration = vi.spyOn(platform.database!, 'applyMigration');
+      const params = {
+        name: tool,
+        arguments: {
+          project_id: project.id,
+          query: RESOURCE_EXHAUSTING_SQL,
+          ...(tool === 'apply_migration' ? { name: 'parser_resource' } : {}),
+        },
+      } satisfies CallToolRequestParams;
+
+      const initial = (await client.request(
+        { method: 'tools/call', params },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+      expect(isInputRequiredResult(initial)).toBe(false);
+      if (isInputRequiredResult(initial)) {
+        throw new Error('resource failure must not elicit');
+      }
+      expect(initial.isError).toBe(true);
+      expect(initial.content).toContainEqual({
+        type: 'text',
+        text: expect.stringContaining('memory exhausted'),
+      });
+      expect(executeSql).not.toHaveBeenCalled();
+      expect(applyMigration).not.toHaveBeenCalled();
+
+      const queryHash = await hashObject({ query: RESOURCE_EXHAUSTING_SQL });
+      const state =
+        tool === 'execute_sql'
+          ? { tool, project_id: project.id, queryHash }
+          : {
+              tool,
+              project_id: project.id,
+              name: 'parser_resource',
+              queryHash,
+            };
+      const requestState = await mintSqlConfirmationState(state);
+      const accepted = (await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            ...params,
+            requestState,
+            inputResponses: {
+              confirm_destructive: { action: 'accept', content: {} },
+            },
+          },
+        },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+
+      expect(isInputRequiredResult(accepted)).toBe(false);
+      if (isInputRequiredResult(accepted)) {
+        throw new Error('resource failure retry must not elicit');
+      }
+      expect(accepted.isError).toBe(true);
+      expect(accepted.content).toContainEqual({
+        type: 'text',
+        text: expect.stringContaining('memory exhausted'),
+      });
+      expect(executeSql).not.toHaveBeenCalled();
+      expect(applyMigration).not.toHaveBeenCalled();
     }
   );
 

--- a/packages/mcp-server-supabase/src/server.test.ts
+++ b/packages/mcp-server-supabase/src/server.test.ts
@@ -4493,6 +4493,85 @@ describe('tools', () => {
     return project;
   }
 
+  test.each([
+    [
+      'execute_sql',
+      "DO $$ BEGIN EXECUTE 'DROP TABLE films'; END $$;",
+      'This SQL contains a DO block whose body contains text suggesting potentially destructive operations.',
+    ],
+    [
+      'apply_migration',
+      "DO $$ BEGIN EXECUTE 'DROP TABLE films'; END $$;",
+      'This SQL contains a DO block whose body contains text suggesting potentially destructive operations.',
+    ],
+    [
+      'execute_sql',
+      'DELETE FROM',
+      'Could not check for destructive operations because the SQL syntax could not be classified. Approving will allow an attempt to execute the original SQL.',
+    ],
+    [
+      'apply_migration',
+      'DELETE FROM',
+      'Could not check for destructive operations because the SQL syntax could not be classified. Approving will allow an attempt to execute the original SQL.',
+    ],
+  ] as const)(
+    'destructive confirmation via elicitation: $tool presents the approved classification wording and approval attempts the original SQL',
+    async (tool, query, firstLine) => {
+      const { client, platform } = await setupModern({
+        clientCapabilities: FORM_CAPABLE,
+      });
+      const project = await createActiveProject();
+      const executeSql = vi.spyOn(platform.database!, 'executeSql');
+      const applyMigration = vi.spyOn(platform.database!, 'applyMigration');
+      const params = {
+        name: tool,
+        arguments: {
+          project_id: project.id,
+          query,
+          ...(tool === 'apply_migration' ? { name: 'parser_policy' } : {}),
+        },
+      } satisfies CallToolRequestParams;
+
+      const first = (await client.request(
+        { method: 'tools/call', params },
+        { allowInputRequired: true }
+      )) as CallToolResult | InputRequiredResult;
+      if (!isInputRequiredResult(first)) {
+        throw new Error('expected an input_required result');
+      }
+      const confirmationRequest = first.inputRequests?.confirm_destructive;
+      if (
+        confirmationRequest?.method !== 'elicitation/create' ||
+        !confirmationRequest.params ||
+        !('message' in confirmationRequest.params) ||
+        typeof confirmationRequest.params.message !== 'string'
+      ) {
+        throw new Error('expected a form elicitation request');
+      }
+      expect(confirmationRequest.params.message.split('\n')[0]).toBe(firstLine);
+      expect(executeSql).not.toHaveBeenCalled();
+      expect(applyMigration).not.toHaveBeenCalled();
+
+      await client.request(
+        {
+          method: 'tools/call',
+          params: {
+            ...params,
+            requestState: first.requestState,
+            inputResponses: {
+              confirm_destructive: { action: 'accept', content: {} },
+            },
+          },
+        },
+        { allowInputRequired: true }
+      );
+
+      const operation = tool === 'execute_sql' ? executeSql : applyMigration;
+      expect(operation).toHaveBeenCalledOnce();
+      expect(operation.mock.calls[0]?.[1]).toMatchObject({ query });
+    }
+  );
+
   describe('execute_sql destructive confirmation via elicitation', () => {
     test('form-capable client: non-destructive SQL runs without elicitation', async () => {
       const { client, platform } = await setupModern({

--- a/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/database-operation-tools.ts
@@ -25,7 +25,10 @@ import {
   executeSqlStateSchema,
   isFormCapable,
 } from './confirmation.js';
-import { isDestructiveSql } from './destructive-sql.js';
+import {
+  getSqlConfirmationReason,
+  type SqlConfirmationReason,
+} from './destructive-sql.js';
 import {
   injectableTool,
   type ToolDefs,
@@ -41,6 +44,17 @@ type DatabaseOperationToolsOptions = {
     enabledTools: readonly ('execute_sql' | 'apply_migration')[];
   };
 };
+
+function sqlConfirmationFirstLine(reason: SqlConfirmationReason) {
+  switch (reason) {
+    case 'destructive':
+      return 'This SQL includes destructive operations (DROP, DELETE, TRUNCATE or UPDATE without WHERE).';
+    case 'do-heuristic':
+      return 'This SQL contains a DO block whose body contains text suggesting potentially destructive operations.';
+    case 'unclassified':
+      return 'Could not check for destructive operations because the SQL syntax could not be classified. Approving will allow an attempt to execute the original SQL.';
+  }
+}
 
 const listTablesInputSchema = z.object({
   project_id: z.string(),
@@ -393,11 +407,12 @@ export function getDatabaseTools({
           throw new Error('Cannot apply migration in read-only mode.');
         }
 
-        if (
+        const confirmationReason =
           confirmation?.enabledTools.includes('apply_migration') &&
-          isFormCapable(ctx) &&
-          isDestructiveSql(query)
-        ) {
+          isFormCapable(ctx)
+            ? await getSqlConfirmationReason(query)
+            : undefined;
+        if (confirmationReason && confirmation) {
           const { codec } = confirmation;
           const queryHash = await hashObject({ query });
           const askForConfirmation = async () =>
@@ -406,7 +421,7 @@ export function getDatabaseTools({
                 confirm_destructive: inputRequired.elicit({
                   mode: 'form',
                   message: [
-                    'This SQL includes destructive operations (DROP, DELETE, TRUNCATE or UPDATE without WHERE).',
+                    sqlConfirmationFirstLine(confirmationReason),
                     'It may permanently remove data, tables, schemas or other objects.',
                     `Apply the migration to project ${project_id}?`,
                   ].join('\n'),
@@ -461,12 +476,13 @@ export function getDatabaseTools({
       },
       inject: { project_id },
       execute: async ({ query, project_id }, ctx: ServerContext) => {
-        if (
+        const confirmationReason =
           !readOnly &&
           confirmation?.enabledTools.includes('execute_sql') &&
-          isFormCapable(ctx) &&
-          isDestructiveSql(query)
-        ) {
+          isFormCapable(ctx)
+            ? await getSqlConfirmationReason(query)
+            : undefined;
+        if (confirmationReason && confirmation) {
           const { codec } = confirmation;
           const queryHash = await hashObject({ query });
           const askForConfirmation = async () =>
@@ -475,7 +491,7 @@ export function getDatabaseTools({
                 confirm_destructive: inputRequired.elicit({
                   mode: 'form',
                   message: [
-                    'This SQL includes destructive operations (DROP, DELETE, TRUNCATE or UPDATE without WHERE).',
+                    sqlConfirmationFirstLine(confirmationReason),
                     'It may permanently remove data, tables, schemas or other objects.',
                     `Run it on project ${project_id}?`,
                   ].join('\n'),

--- a/packages/mcp-server-supabase/src/tools/destructive-sql.test.ts
+++ b/packages/mcp-server-supabase/src/tools/destructive-sql.test.ts
@@ -1,135 +1,164 @@
-import { describe, expect, test } from 'vitest';
+import type { ParseResult } from 'libpg-query';
+import * as parser from 'libpg-query';
+import { describe, expect, test, vi } from 'vitest';
 
-import {
-  checkDestructiveQuery,
-  isDestructiveSql,
-  isUpdateWithoutWhere,
-} from './destructive-sql.js';
+import { getSqlConfirmationReason } from './destructive-sql.js';
 
-describe('checkDestructiveQuery', () => {
-  test('drop statement matches', () => {
-    expect(checkDestructiveQuery('drop table films, distributors;')).toBe(true);
-  });
-
-  test('truncate statement matches', () => {
-    expect(checkDestructiveQuery('truncate films;')).toBe(true);
-  });
-
-  test('delete statement matches', () => {
-    expect(
-      checkDestructiveQuery("delete from films where kind <> 'Musical';")
-    ).toBe(true);
-  });
-
-  test('delete statement after another statement matches', () => {
-    expect(
-      checkDestructiveQuery(`
-        select * from films;
-        delete from films where kind <> 'Musical';
-      `)
-    ).toBe(true);
-  });
-
-  test('RLS policy containing delete does not match', () => {
-    expect(
-      checkDestructiveQuery(`
-        create policy "Users can delete their own files"
-        on storage.objects for delete to authenticated using (
-          bucket_id = 'files' and (select auth.uid()) = owner
-        );
-      `)
-    ).toBe(false);
-  });
-
-  test('comment containing keywords does not match', () => {
-    expect(
-      checkDestructiveQuery(`
-        -- Going to drop this in here, might delete later
-        select * from films;
-      `)
-    ).toBe(false);
-  });
-
-  test('capitalized statement matches', () => {
-    expect(
-      checkDestructiveQuery("DELETE FROM films WHERE kind <> 'Musical';")
-    ).toBe(true);
-  });
-
-  test('EXECUTE string containing DROP TABLE matches', () => {
-    expect(checkDestructiveQuery("EXECUTE 'DROP TABLE films';")).toBe(true);
-  });
+vi.mock('libpg-query', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof parser;
+  return { ...actual, parse: vi.fn(actual.parse) };
 });
 
-describe('isUpdateWithoutWhere', () => {
-  test('update with WHERE does not match', () => {
-    expect(
-      isUpdateWithoutWhere(
-        "UPDATE public.countries SET name = 'New Name' WHERE id = 1;"
-      )
-    ).toBe(false);
+describe('getSqlConfirmationReason', () => {
+  test.each([
+    'DROP TABLE films;',
+    'DROP DATABASE films;',
+    'DROP ROLE archivist;',
+    'DROP OWNED BY archivist;',
+    'DROP TABLESPACE archive;',
+    'DROP USER MAPPING FOR archivist SERVER warehouse;',
+    'DROP SUBSCRIPTION archive;',
+    'DELETE FROM films WHERE id = 1;',
+    'TRUNCATE films;',
+  ])('classifies destructive statements: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBe('destructive');
   });
 
-  test('update without WHERE matches', () => {
-    expect(
-      isUpdateWithoutWhere("UPDATE public.countries SET name = 'New Name';")
-    ).toBe(true);
+  test('classifies every statement in a batch without preprocessing quoted markers', async () => {
+    await expect(
+      getSqlConfirmationReason("SELECT '--';\nDROP TABLE films;")
+    ).resolves.toBe('destructive');
   });
 
-  test('quoted identifier containing where without WHERE matches', () => {
-    expect(isUpdateWithoutWhere('UPDATE "where table" SET id = 1;')).toBe(true);
+  test.each([
+    'UPDATE films SET title = null;',
+    'UPDATE films SET title = (SELECT title FROM archive WHERE id = 1);',
+    "UPDATE films SET title = 'where now';",
+  ])('classifies UPDATE using its own WHERE clause: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBe('destructive');
   });
 
-  test('string literal containing where without WHERE matches', () => {
-    expect(isUpdateWithoutWhere("UPDATE films SET title = 'where now';")).toBe(
-      true
-    );
-  });
-});
-
-describe('isDestructiveSql', () => {
-  test('select statement does not match', () => {
-    expect(isDestructiveSql('select * from films;')).toBe(false);
-  });
-
-  test('composite destructive query matches', () => {
-    expect(
-      isDestructiveSql('select * from films; UPDATE films SET title = null;')
-    ).toBe(true);
+  test.each([
+    'UPDATE films SET title = null WHERE id = 1;',
+    'UPDATE films SET title = null WHERE true;',
+  ])('does not classify UPDATE with an outer WHERE: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBeUndefined();
   });
 
   test.each([
     'ALTER TABLE films DROP title;',
-    'ALTER TABLE public.films DROP title;',
-    'ALTER TABLE "public"."film archive" DROP "display title";',
-    'ALTER TABLE "film""archive" DROP "display""title";',
-    'ALTER TABLE IF EXISTS public.films DROP IF EXISTS title;',
-    'ALTER TABLE ONLY public.films DROP title CASCADE;',
-    'ALTER TABLE ONLY "public"."films" DROP COLUMN IF EXISTS "title" RESTRICT;',
-    'ALTER TABLE films DROP "constraint";',
-    'ALTER TABLE films DROP constraint$archive;',
-    'ALTER TABLE films DROP constrainté;',
-    'SELECT 1;\nALTER TABLE films DROP title;',
-  ])('direct DROP-column action matches: %s', (sql) => {
-    expect(isDestructiveSql(sql)).toBe(true);
+    'ALTER TABLE public.films DROP COLUMN IF EXISTS title CASCADE;',
+    'ALTER TABLE ONLY "public"."film archive" DROP "display title";',
+    'ALTER TABLE films ADD COLUMN rating int, DROP title;',
+  ])('classifies TABLE column drops: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBe('destructive');
   });
 
   test.each([
     'ALTER TABLE films DROP CONSTRAINT films_pkey;',
-    'ALTER TABLE "public"."films" DROP CONSTRAINT IF EXISTS films_pkey;',
     'ALTER TABLE films ALTER COLUMN title DROP DEFAULT;',
     'ALTER TABLE films ALTER COLUMN title DROP NOT NULL;',
     'ALTER TABLE films ALTER COLUMN id DROP IDENTITY;',
     'ALTER TABLE films ALTER COLUMN title DROP EXPRESSION;',
-  ])('other ALTER actions remain outside the policy: %s', (sql) => {
-    expect(isDestructiveSql(sql)).toBe(false);
+    'ALTER TYPE inventory_item DROP ATTRIBUTE supplier_id;',
+  ])('leaves other ALTER actions outside the policy: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBeUndefined();
   });
 
   test.each([
-    'ALTER TABLE films DROP COLUMN title;',
-    'ALTER TABLE films ADD COLUMN rating int, DROP COLUMN title;',
-    "DO $$ BEGIN EXECUTE 'ALTER TABLE films DROP COLUMN title'; END $$;",
-  ])('existing explicit-column detection is preserved: %s', (sql) => {
-    expect(isDestructiveSql(sql)).toBe(true);
+    'WITH removed AS (DELETE FROM films RETURNING *) SELECT * FROM removed;',
+    'WITH removed AS (DELETE FROM films RETURNING *) UPDATE films SET title = null WHERE id = 1;',
+    'INSERT INTO archive WITH removed AS (DELETE FROM films RETURNING *) SELECT * FROM removed;',
+  ])('classifies executing destructive CTEs: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBe('destructive');
   });
+
+  test.each([
+    'EXPLAIN (ANALYZE) DELETE FROM films;',
+    'EXPLAIN (ANALYZE true) DELETE FROM films;',
+    'EXPLAIN (ANALYZE ON) DELETE FROM films;',
+    'EXPLAIN (ANALYZE 1) DELETE FROM films;',
+    'EXPLAIN (ANALYZE false, ANALYZE true) DELETE FROM films;',
+  ])('classifies executing EXPLAIN statements: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBe('destructive');
+  });
+
+  test.each([
+    'EXPLAIN DELETE FROM films;',
+    'EXPLAIN (ANALYZE false) DELETE FROM films;',
+    'EXPLAIN (ANALYZE OFF) DELETE FROM films;',
+    'EXPLAIN (ANALYZE 0) DELETE FROM films;',
+    'EXPLAIN (ANALYZE true, ANALYZE false) DELETE FROM films;',
+  ])('does not classify nonexecuting EXPLAIN statements: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBeUndefined();
+  });
+
+  test.each([
+    "EXPLAIN (ANALYZE '1') DELETE FROM films;",
+    'EXPLAIN (ANALYZE yes) DELETE FROM films;',
+    'EXPLAIN (ANALYZE maybe, ANALYZE false) DELETE FROM films;',
+    'EXPLAIN (ANALYZE 2) DELETE FROM films;',
+  ])('does not silently accept invalid ANALYZE values: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBe('unclassified');
+  });
+
+  test.each([
+    "DO $$ BEGIN EXECUTE 'DROP TABLE films'; END $$;",
+    "DO $$ BEGIN EXECUTE format('DROP TABLE %I', 'films'); END $$;",
+    "DO $$ BEGIN EXECUTE concat('DROP ', 'TABLE films'); END $$;",
+    'DO $$ BEGIN PERFORM 1; DELETE FROM films; END $$;',
+  ])(
+    'uses the retained predicate only for extracted DO bodies: %s',
+    async (sql) => {
+      await expect(getSqlConfirmationReason(sql)).resolves.toBe('do-heuristic');
+    }
+  );
+
+  test.each([
+    'DO $$ BEGIN DELETE FROM films; END $$;',
+    "DO $$ DECLARE command text := 'DROP TABLE films'; BEGIN EXECUTE command; END $$;",
+    "DO $$ BEGIN RAISE NOTICE 'DELETE FROM films'; END $$;",
+    "DO $$ BEGIN -- EXECUTE 'DROP TABLE films';\nRAISE NOTICE 'done'; END $$;",
+    "CREATE FUNCTION remove_films() RETURNS void LANGUAGE plpgsql AS $$ BEGIN EXECUTE 'DROP TABLE films'; END $$;",
+  ])(
+    'preserves accepted DO gaps and stored-body exclusions: %s',
+    async (sql) => {
+      await expect(getSqlConfirmationReason(sql)).resolves.toBeUndefined();
+    }
+  );
+
+  test.each([
+    "SELECT 'DELETE FROM films';",
+    'CREATE POLICY p ON films FOR DELETE USING (true);',
+    '-- DROP TABLE films;\nSELECT 1;',
+    'PREPARE remove_films AS DELETE FROM films;',
+    '-- comment only',
+  ])('does not traverse data or nonexecuting wrappers: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBeUndefined();
+  });
+
+  test.each(['', '   ', 'DELETE FROM'])(
+    'classifies known-empty or malformed SQL as unknown: %s',
+    async (sql) => {
+      await expect(getSqlConfirmationReason(sql)).resolves.toBe('unclassified');
+    }
+  );
+
+  test.each([
+    [{}, 'SQL parser returned an invalid statement list.'],
+    [
+      { stmts: [{ stmt: undefined }] },
+      'SQL parser returned an invalid statement.',
+    ],
+    [{ stmts: [{ stmt: [] }] }, 'SQL parser returned an invalid statement.'],
+  ] as const)(
+    'keeps malformed successful parser output terminal',
+    async (result, message) => {
+      vi.mocked(parser.parse).mockResolvedValueOnce(result as ParseResult);
+
+      await expect(getSqlConfirmationReason('SELECT 1')).rejects.toThrow(
+        message
+      );
+    }
+  );
 });

--- a/packages/mcp-server-supabase/src/tools/destructive-sql.test.ts
+++ b/packages/mcp-server-supabase/src/tools/destructive-sql.test.ts
@@ -9,6 +9,10 @@ vi.mock('libpg-query', async (importOriginal) => {
   return { ...actual, parse: vi.fn(actual.parse) };
 });
 
+const RESOURCE_EXHAUSTING_SQL = `SELECT ${'('.repeat(10_000)}1${')'.repeat(
+  10_000
+)};`;
+
 describe('getSqlConfirmationReason', () => {
   test.each([
     'DROP TABLE films;',
@@ -137,12 +141,55 @@ describe('getSqlConfirmationReason', () => {
     await expect(getSqlConfirmationReason(sql)).resolves.toBeUndefined();
   });
 
-  test.each(['', '   ', 'DELETE FROM'])(
-    'classifies known-empty or malformed SQL as unknown: %s',
-    async (sql) => {
-      await expect(getSqlConfirmationReason(sql)).resolves.toBe('unclassified');
-    }
-  );
+  test.each([
+    '',
+    '   ',
+    'DELETE FROM',
+    "SELECT 'unterminated",
+    'SELECT "";',
+    'SELECT 1abc;',
+    'SELECT 1 LIMIT 1, 2;',
+    'SELECT 1 FETCH FIRST 1 ROWS WITH TIES;',
+    'SELECT * FROM a.b.c.d;',
+    'CREATE TABLE t (a text COLLATE "C" COLLATE "POSIX");',
+    "SELECT E'\\uZZZZ';",
+    "SELECT U&'\\+110000';",
+    "SELECT U&'\\D800';",
+  ])('classifies known-empty or malformed SQL as unknown: %s', async (sql) => {
+    await expect(getSqlConfirmationReason(sql)).resolves.toBe('unclassified');
+  });
+
+  test('keeps a real parser resource failure terminal', async () => {
+    expect(Buffer.byteLength(RESOURCE_EXHAUSTING_SQL)).toBe(20_009);
+
+    await expect(
+      getSqlConfirmationReason(RESOURCE_EXHAUSTING_SQL)
+    ).rejects.toThrow('memory exhausted');
+  });
+
+  test('keeps an unknown SqlError terminal at the scanner seam', async () => {
+    const error = new parser.SqlError('unexpected parser failure', {
+      message: 'unexpected parser failure',
+      cursorPosition: 0,
+      fileName: 'scan.l',
+      functionName: 'scanner_yyerror',
+    });
+    vi.mocked(parser.parse).mockRejectedValueOnce(error);
+
+    await expect(getSqlConfirmationReason('SELECT 1')).rejects.toBe(error);
+  });
+
+  test('keeps a nearby parser helper internal error terminal', async () => {
+    const error = new parser.SqlError('invalid hexadecimal digit', {
+      message: 'invalid hexadecimal digit',
+      cursorPosition: 0,
+      fileName: 'src_backend_parser_parser.c',
+      functionName: 'hexval',
+    });
+    vi.mocked(parser.parse).mockRejectedValueOnce(error);
+
+    await expect(getSqlConfirmationReason('SELECT 1')).rejects.toBe(error);
+  });
 
   test.each([
     [{}, 'SQL parser returned an invalid statement list.'],

--- a/packages/mcp-server-supabase/src/tools/destructive-sql.ts
+++ b/packages/mcp-server-supabase/src/tools/destructive-sql.ts
@@ -1,3 +1,5 @@
+import type { ParseResult } from 'libpg-query';
+
 /** Adapted from supabase/supabase apps/studio (SQLEditor.constants.ts, SQLEditor.utils.ts, lib/helpers.ts), Apache-2.0. */
 
 const sqlIdentifier = String.raw`(?:"(?:[^"]|"")+"|[a-z_\u0080-\uffff][\w$\u0080-\uffff]*)`;
@@ -36,7 +38,7 @@ const destructiveSqlRegex = [
 const updateWithoutWhereRegex =
   /(?:^|;)\s*update\s+(?:"(?:[^"]|"")+"|[\w]+)(?:\.(?:"(?:[^"]|"")+"|[\w]+))?\s+set\s+[\w\W]+?(?!\s*where\s)/is;
 
-export function removeCommentsFromSql(sql: string): string {
+function removeCommentsFromSql(sql: string): string {
   // Removing single-line comments:
   let cleanedSql = sql.replace(/--.*$/gm, '');
 
@@ -46,7 +48,7 @@ export function removeCommentsFromSql(sql: string): string {
   return cleanedSql;
 }
 
-export function checkDestructiveQuery(sql: string): boolean {
+function checkDestructiveQuery(sql: string): boolean {
   const cleanedSql = removeCommentsFromSql(sql);
   return destructiveSqlRegex.some((regex) => regex.test(cleanedSql));
 }
@@ -59,7 +61,7 @@ export function checkDestructiveQuery(sql: string): boolean {
 const stripQuotedSpans = (sql: string) =>
   sql.replace(/'(?:''|[^'])*'/g, "''").replace(/"(?:""|[^"])*"/g, '""');
 
-export function isUpdateWithoutWhere(sql: string): boolean {
+function isUpdateWithoutWhere(sql: string): boolean {
   const updateStatements = sql
     .split(';')
     .filter((statement) => statement.trim().toLowerCase().startsWith('update'));
@@ -70,6 +72,202 @@ export function isUpdateWithoutWhere(sql: string): boolean {
   );
 }
 
-export function isDestructiveSql(sql: string): boolean {
+function oldPredicateMatches(sql: string): boolean {
   return checkDestructiveQuery(sql) || isUpdateWithoutWhere(sql);
+}
+
+type AstObject = Record<string, unknown>;
+export type SqlConfirmationReason =
+  | 'destructive'
+  | 'do-heuristic'
+  | 'unclassified';
+type ClassifiedReason = Exclude<SqlConfirmationReason, 'unclassified'>;
+
+const dropNodeNames = [
+  'DropStmt',
+  'DropdbStmt',
+  'DropRoleStmt',
+  'DropOwnedStmt',
+  'DropTableSpaceStmt',
+  'DropUserMappingStmt',
+  'DropSubscriptionStmt',
+] as const;
+
+class UnsupportedSqlAstError extends Error {}
+
+function asObject(value: unknown): AstObject | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as AstObject)
+    : undefined;
+}
+
+function nodeValue(node: AstObject, key: string): AstObject | undefined {
+  return asObject(node[key]);
+}
+
+function classifyCtes(statement: AstObject): ClassifiedReason | undefined {
+  const ctes = asObject(statement.withClause)?.ctes;
+  if (!Array.isArray(ctes)) return undefined;
+
+  for (const cteNode of ctes) {
+    const cte = nodeValue(asObject(cteNode) ?? {}, 'CommonTableExpr');
+    const query = asObject(cte?.ctequery);
+    if (!query) continue;
+
+    const reason = classifyStatement(query);
+    if (reason) return reason;
+  }
+
+  return undefined;
+}
+
+function parseExplainBoolean(value: unknown): boolean {
+  if (value === undefined) return true;
+
+  const argument = asObject(value);
+  const integer = argument && nodeValue(argument, 'Integer');
+  if (integer) {
+    const numericValue = integer.ival ?? 0;
+    if (numericValue === 0) return false;
+    if (numericValue === 1) return true;
+    throw new UnsupportedSqlAstError('invalid EXPLAIN ANALYZE integer');
+  }
+
+  const string = argument && nodeValue(argument, 'String');
+  if (string && typeof string.sval === 'string') {
+    switch (string.sval.toLowerCase()) {
+      case 'true':
+      case 'on':
+        return true;
+      case 'false':
+      case 'off':
+        return false;
+      default:
+        throw new UnsupportedSqlAstError('invalid EXPLAIN ANALYZE string');
+    }
+  }
+
+  throw new UnsupportedSqlAstError('unsupported EXPLAIN ANALYZE value');
+}
+
+function explainExecutes(explain: AstObject): boolean {
+  const options = explain.options;
+  if (options === undefined) return false;
+  if (!Array.isArray(options)) {
+    throw new UnsupportedSqlAstError('unsupported EXPLAIN options');
+  }
+
+  let analyze = false;
+  for (const optionNode of options) {
+    const option = nodeValue(asObject(optionNode) ?? {}, 'DefElem');
+    if (option?.defname !== 'analyze') continue;
+    analyze = parseExplainBoolean(option.arg);
+  }
+  return analyze;
+}
+
+function classifyDo(doStatement: AstObject): ClassifiedReason | undefined {
+  if (!Array.isArray(doStatement.args)) return undefined;
+
+  for (const argumentNode of doStatement.args) {
+    const argument = nodeValue(asObject(argumentNode) ?? {}, 'DefElem');
+    if (argument?.defname !== 'as') continue;
+
+    const body = argument.arg
+      ? nodeValue(asObject(argument.arg) ?? {}, 'String')
+      : undefined;
+    const bodyText = body?.sval;
+    if (typeof bodyText === 'string' && oldPredicateMatches(bodyText)) {
+      return 'do-heuristic';
+    }
+  }
+
+  return undefined;
+}
+
+function classifyStatement(node: AstObject): ClassifiedReason | undefined {
+  if (dropNodeNames.some((name) => name in node)) return 'destructive';
+  if ('DeleteStmt' in node || 'TruncateStmt' in node) return 'destructive';
+
+  const alterTable = nodeValue(node, 'AlterTableStmt');
+  if (alterTable) {
+    if (
+      alterTable.objtype !== 'OBJECT_TABLE' ||
+      !Array.isArray(alterTable.cmds)
+    ) {
+      return undefined;
+    }
+    return alterTable.cmds.some(
+      (commandNode) =>
+        nodeValue(asObject(commandNode) ?? {}, 'AlterTableCmd')?.subtype ===
+        'AT_DropColumn'
+    )
+      ? 'destructive'
+      : undefined;
+  }
+
+  const update = nodeValue(node, 'UpdateStmt');
+  if (update)
+    return (
+      classifyCtes(update) ?? (update.whereClause ? undefined : 'destructive')
+    );
+
+  const select = nodeValue(node, 'SelectStmt');
+  if (select) return classifyCtes(select);
+
+  const insert = nodeValue(node, 'InsertStmt');
+  if (insert) {
+    const cteReason = classifyCtes(insert);
+    if (cteReason) return cteReason;
+
+    const selectStatement = asObject(insert.selectStmt);
+    return selectStatement ? classifyStatement(selectStatement) : undefined;
+  }
+
+  const explain = nodeValue(node, 'ExplainStmt');
+  if (explain) {
+    if (!explainExecutes(explain)) return undefined;
+    const query = asObject(explain.query);
+    if (!query) throw new UnsupportedSqlAstError('missing EXPLAIN query');
+    return classifyStatement(query);
+  }
+
+  const doStatement = nodeValue(node, 'DoStmt');
+  return doStatement ? classifyDo(doStatement) : undefined;
+}
+
+export async function getSqlConfirmationReason(
+  sql: string
+): Promise<SqlConfirmationReason | undefined> {
+  if (sql.trim() === '') return 'unclassified';
+  // Keep the WASM parser off paths where SQL confirmation is disabled or unsupported.
+
+  const parser = await import('libpg-query');
+  let parsed: ParseResult;
+  try {
+    parsed = await parser.parse(sql);
+  } catch (error) {
+    if (error instanceof parser.SqlError) return 'unclassified';
+    throw error;
+  }
+  if (!Array.isArray(parsed.stmts)) {
+    throw new Error('SQL parser returned an invalid statement list.');
+  }
+
+  try {
+    for (const rawStatementValue of parsed.stmts) {
+      const rawStatement = asObject(rawStatementValue);
+      const statement = rawStatement && asObject(rawStatement.stmt);
+      if (!statement) {
+        throw new Error('SQL parser returned an invalid statement.');
+      }
+
+      const reason = classifyStatement(statement);
+      if (reason) return reason;
+    }
+    return undefined;
+  } catch (error) {
+    if (error instanceof UnsupportedSqlAstError) return 'unclassified';
+    throw error;
+  }
 }

--- a/packages/mcp-server-supabase/src/tools/destructive-sql.ts
+++ b/packages/mcp-server-supabase/src/tools/destructive-sql.ts
@@ -1,4 +1,4 @@
-import type { ParseResult } from 'libpg-query';
+import type { ParseResult, SqlError } from 'libpg-query';
 
 /** Adapted from supabase/supabase apps/studio (SQLEditor.constants.ts, SQLEditor.utils.ts, lib/helpers.ts), Apache-2.0. */
 
@@ -82,6 +82,67 @@ export type SqlConfirmationReason =
   | 'do-heuristic'
   | 'unclassified';
 type ClassifiedReason = Exclude<SqlConfirmationReason, 'unclassified'>;
+const scannerSyntaxErrorPrefixes = [
+  'syntax error',
+  'unterminated ',
+  'invalid Unicode ',
+  'zero-length delimited identifier',
+  'operator too long',
+  'parameter number too large',
+  'trailing junk after ',
+  'invalid hexadecimal integer',
+  'invalid octal integer',
+  'invalid binary integer',
+  'UESCAPE must be followed by a simple string literal',
+] as const;
+
+function isSupportedSyntaxError(error: SqlError): boolean {
+  const { fileName, functionName } = error.sqlDetails ?? {};
+
+  if (fileName === 'gram.y') {
+    switch (functionName) {
+      case 'base_yyparse':
+      case 'makeOrderedSetArgs':
+      case 'insertSelectOptions':
+      case 'mergeTableFuncParameters':
+      case 'makeRangeVarFromAnyName':
+      case 'makeRangeVarFromQualifiedName':
+      case 'processCASbits':
+      case 'parsePartitionStrategy':
+      case 'preprocess_pubobj_list':
+        return true;
+      case 'SplitColQualList':
+        return error.message === 'multiple COLLATE clauses not allowed';
+    }
+  }
+
+  if (fileName === 'scan.l' && functionName === 'core_yylex') {
+    return error.message === 'invalid Unicode escape';
+  }
+
+  if (fileName === 'src_backend_parser_parser.c') {
+    if (functionName === 'check_unicode_value') {
+      return error.message === 'invalid Unicode escape value';
+    }
+    if (functionName === 'str_udeescape') {
+      return (
+        error.message === 'invalid Unicode escape' ||
+        error.message === 'invalid Unicode surrogate pair'
+      );
+    }
+  }
+
+  // Bison grammar errors and scan.l's lexer errors share this function.
+  // Match only source-backed messages: resource errors use the same SqlError
+  // class, source file, and scanner function.
+  return (
+    fileName === 'scan.l' &&
+    functionName === 'scanner_yyerror' &&
+    scannerSyntaxErrorPrefixes.some((prefix) =>
+      error.message.startsWith(prefix)
+    )
+  );
+}
 
 const dropNodeNames = [
   'DropStmt',
@@ -247,7 +308,9 @@ export async function getSqlConfirmationReason(
   try {
     parsed = await parser.parse(sql);
   } catch (error) {
-    if (error instanceof parser.SqlError) return 'unclassified';
+    if (error instanceof parser.SqlError && isSupportedSyntaxError(error)) {
+      return 'unclassified';
+    }
     throw error;
   }
   if (!Array.isArray(parsed.stmts)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       graphql:
         specifier: ^16.11.0
         version: 16.11.0
+      libpg-query:
+        specifier: 18.1.5-lowmem-32.0
+        version: 18.1.5-lowmem-32.0
       openapi-fetch:
         specifier: ^0.13.5
         version: 0.13.8
@@ -812,6 +815,9 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@pgsql/types@18.0.0':
+    resolution: {integrity: sha512-jtAY4JU7jdVYZ/Vv3zlZqVP+FRWZokyCLKPPCnAApiaJAElpyyiMC3HRiquBu29kSrVs+rkqZD50SUIb/zyEGw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1372,6 +1378,9 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  libpg-query@18.1.5-lowmem-32.0:
+    resolution: {integrity: sha512-qMDXv/BAcnWRHz2i3RQcXIKJGarf+LCiYNm2rhSgFs11VJyLUiUn7TP4wIUD+em/FjfRfJdRqoUVrHyqo7G5Fw==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -2451,6 +2460,8 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@pgsql/types@18.0.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -2966,6 +2977,10 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema@0.4.0: {}
+
+  libpg-query@18.1.5-lowmem-32.0:
+    dependencies:
+      '@pgsql/types': 18.0.0
 
   lilconfig@3.1.3: {}
 


### PR DESCRIPTION
## Why

Regex checks can mistake strings and comments for SQL structure, missing destructive statements. For example, `SELECT '--';` can hide a following DROP, and a WHERE inside a nested SELECT can hide an UPDATE without its own WHERE.

This replaces those ordinary-SQL checks with parsing. Stacked on [#408](https://github.com/supabase/mcp/pull/408), with `feat/destructive-sql-confirmation` as the base branch.

## What changed

- **Check SQL structure.** Detect DROP, DELETE, TRUNCATE, UPDATE without its own WHERE, and table-column drops, including operations in executing CTEs. EXPLAIN checks the wrapped query only when ANALYZE enables execution.
- **Keep procedural detection best-effort.** DO, an anonymous procedural block, retains text checks within its body only. If those checks suggest potentially destructive operations, the tool asks for confirmation before executing the original SQL. A nonmatch does not trigger confirmation from that body check, but does not mean the block is safe; other destructive statements can still trigger confirmation. Stored-function creation no longer warns about its unexecuted body; CALL and other runtime effects remain outside coverage.
- **Separate syntax from operational failures.** Recognized syntax failures ask for consent before attempting the original SQL. Resource and unknown parser failures stop the request, including accepted retries. Error recognition is version-specific and requires review when upgrading.
- **Preserve confirmation safeguards.** Read-only, per-tool and form-capability gates, original SQL and argument bindings, and existing destructive prompts and decline/cancel behavior stay intact.

## Rationale

Use the direct [`libpg-query@18.1.5-lowmem-32.0`](https://registry.npmjs.org/libpg-query/18.1.5-lowmem-32.0) package rather than adding a wrapper. Its PostgreSQL-derived parser supplies statement structure that regex cannot reliably recover.

The parser loads only when classification is needed, and module-level initialization is reused for later queries rather than creating an instance per query. This build starts with 32MiB linear memory and an 8MiB stack, versus 128MiB and 32MiB for the default PG18 build. Smaller initial allocation is not a leak fix or an RSS budget.

## How to test

These instructions are derived from source and documentation, not a live staging or production run.

1. **Choose one disposable target and prepare your tools.** Use either:
   - **Staging:** API `https://api.supabase.green`, an existing staging personal access token (PAT), and a disposable staging project ref.
   - **Dedicated disposable production:** API `https://api.supabase.com`, an existing production PAT, and that disposable production project's ref.

   The server API URL, PAT, and project ref must all match your choice. **Never use customer, shared, or application data.**

   Check out this PR (`feat/destructive-sql-parser`) locally. Have the repository's Node LTS and pnpm 10 active ([tool setup](https://github.com/supabase/mcp/blob/a4f435165357d9ddaa7bf3e7b0fc4bbfcb9bc07d/CONTRIBUTING.md)), plus a current Claude Code version with MCP elicitation form support. Disable elicitation auto-answer hooks for this session.

2. **Build and start the local HTTP server in Terminal A.** Replace `/path/to/this-pr-checkout` with your checkout root: the folder containing `package.json` and `packages/`.

   ```sh
   cd /path/to/this-pr-checkout
   pnpm install
   pnpm --config.enable-pre-post-scripts=true --filter '@supabase/mcp-server-supabase...' build
   ```

   For **staging**, start:

   ```sh
   node packages/mcp-server-supabase/dist/cli.js --http --port 3111 --api-url https://api.supabase.green
   ```

   For **dedicated disposable production**, replace only `https://api.supabase.green` with `https://api.supabase.com` in that command. Leave Terminal A running; HTTP mode does not need a server-side PAT export.

   Reuse an existing server only if it runs this PR with your chosen API URL and port. Otherwise, use a free port and change `3111` in both the launch command and the config below. Do not stop an unrelated server.

3. **Create a private `.mcp.json` at the checkout root.** Open Terminal B using interactive **bash or zsh**, then enter the same folder:

   ```sh
   cd /path/to/this-pr-checkout
   git ls-files -- .mcp.json
   ```

   If that command lists `.mcp.json`, stop: an ignore rule cannot protect a tracked file. If the file already exists, do not overwrite it or add a duplicate registration. Privately reuse only a suitable entry matching the local endpoint, disposable target, `read_only=false`, database tools, and environment-backed PAT shown below. If incompatible, stop rather than modify, delete, or untrack it. When reusing an entry, use its actual server name and environment-variable names in the remaining steps.

   **For a new file**, first add this repository-local exclusion, not a tracked `.gitignore` change:

   ```sh
   printf '\n/.mcp.json\n' >> "$(git rev-parse --git-path info/exclude)"
   ```

   In a local text editor, create `.mcp.json` directly beside the root `package.json`, **not** inside `packages/mcp-server-supabase` or `~/.claude`. Paste this JSON, keeping both `${...}` placeholders literal. Never put a token in the file.

   ```json
   {
     "mcpServers": {
       "supabase-sql-review": {
         "type": "http",
         "url": "http://127.0.0.1:3111/mcp?project_ref=${SUPABASE_REVIEW_PROJECT_REF}&read_only=false&features=database",
         "headers": {
           "Authorization": "Bearer ${SUPABASE_REVIEW_PAT}"
         }
       }
     }
   }
   ```

   Check that the file is ignored:

   ```sh
   git check-ignore .mcp.json
   ```

   Expect `.mcp.json` as output; otherwise stop. Keep this config local and do not force-add or commit it. The local URL stays the same for either environment; the server's `--api-url` selects staging or production.

4. **Enter your existing PAT and launch Claude from Terminal B.** Run these commands one at a time, answering each prompt before continuing. Enter the PAT only at the silent input prompt, never as a shell command or JSON value. Stop if either input is missing or does not match your chosen environment.

   ```sh
   printf 'Chosen disposable project ref: ' >&2
   IFS= read -r SUPABASE_REVIEW_PROJECT_REF
   export SUPABASE_REVIEW_PROJECT_REF
   printf 'Existing PAT for the same environment: ' >&2
   IFS= read -r -s SUPABASE_REVIEW_PAT
   printf '\n' >&2
   export SUPABASE_REVIEW_PAT
   claude --tools "" --strict-mcp-config --mcp-config .mcp.json
   ```

   In Claude, use `/mcp` to confirm that `supabase-sql-review` (or your reused entry) is connected. Privately verify the actual target, not just the connection label. Stop on ambiguity or connection failure; do not switch servers or use an OAuth workaround.

   `--tools ""` disables built-in tools, not MCP tools. Strict config loads only the supplied config, but **every server in that file can load**. Use only the selected server's `execute_sql` and `apply_migration`. The PAT remains in process environment/memory: do not print the environment, expose secrets in logs/screenshots, or ask Claude to inspect the config.

5. **Run the [attached manual test prompt](https://github.com/user-attachments/files/32159044/claude-code-manual-sql-elicitation-test-prompt.md).** Open the attachment and copy its reusable prompt into Claude. Before that prompt, add the following with all three bracketed values replaced:

   ```text
   Target environment: [staging or dedicated disposable production]
   MCP server: [supabase-sql-review or your selected server name]
   Exact disposable project ref: [your chosen project ref]

   The attachment calls staging "Green". If I selected dedicated disposable
   production above, its Green references mean only that explicitly named
   disposable production target. Do not switch environments or servers.
   Confirm this disposable target with me before any writes. All other
   safety instructions in the prompt still apply.
   ```

   Follow the attachment's full SQL/migration matrix, cancellation checks, and cleanup. Answer the actual server elicitation forms manually; normal tool-permission dialogs are separate and do not count. Initial target confirmation does not replace per-operation forms. Successful migrations can leave migration-history records after schema cleanup; do not delete that history.

## Trade-offs

- **Memory:** combined client/server/confirmation/parser RSS reached **684MB**, not an isolated parser measurement or budget acceptance.
- **Complex SQL performance remains unverified:** the largest measured input was mostly a comment.
- **Dynamic SQL is best-effort:** variable-assembled SQL and quote/comment cases can still be missed.
- **Hosted parsing needs rollout measurements.** The same package can run in hosted handlers, but after shared initialization, parsing runs synchronously on the caller's JS thread; the async interface does not offload it. Before hosted production enablement, we need representative eligible per-replica peak-load measurements of cold/warm latency, event-loop responsiveness, and process/cgroup memory against owned budgets. We're awaiting Pedro's existing stress results; no byte cap or worker pool has been selected.
