### PR TITLE
feat(mcp-utils): add bounded request lifecycle observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ The PostgREST MCP server allows you to connect your own users to your app via RE
 
 See [CONTRIBUTING](./CONTRIBUTING.md) for details on how to contribute to this project.
 
+See [Observability](docs/observability.md) for the observer API.
+
 ## License
 
 This project is licensed under Apache 2.0. See the [LICENSE](./LICENSE) file for details.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,88 @@
+# Observability
+
+The server provides an optional, vendor-neutral observer for five request-handler lifecycles and bounded facts recorded by tools, without exposing request contents. No collection, host metrics, provider, exporter, queue, or host adoption is configured by this API.
+
+## API and ownership
+
+Set `observer?: RequestObserver` on `McpServerOptions` for `createMcpServer`.
+
+`@supabase/mcp-utils` exports:
+
+- `ObservedMethod`
+- `ObservedTool`
+- `ObservationContext`
+- `ConfirmationFeature`
+- `ObservationFact`
+- `ObservationEnd`
+- `RequestObservation`
+- `RequestObserver`
+
+`RequestObserver` is a synchronous factory. Invoking it begins observation. It receives `{ method, tool }` and returns a `RequestObservation` or `undefined`. Its returned observation methods are:
+
+- `record(fact): void | Promise<void>`
+- `end({ result, durationMs }): void | Promise<void>`
+
+Only the handler owns `end`. Tool code receives an optional safe, synchronous recorder through the additive third argument to `Tool.execute(params, context, record?: (fact: ObservationFact) => void)`. Existing one- and two-argument callers continue to work.
+
+The observer factory must not return a Promise. An unsupported Promise return is discarded, with its rejection consumed.
+
+## Request scope
+
+| `ObservedMethod` | Tool classification |
+| --- | --- |
+| `tools/call` | `create_project`, `create_branch`, `execute_sql`, `apply_migration`, or `other` |
+| `tools/list` | `not_applicable` |
+| `resources/list` | `not_applicable` |
+| `resources/templates/list` | `not_applicable` |
+| `resources/read` | `not_applicable` |
+
+Unknown tool names become `other`; raw names are not emitted. Initialize requests, notifications, unknown methods, and SDK rejections before handler entry do not create scopes.
+
+Currently, `execute_sql` and `apply_migration` are general handler buckets only. They emit no confirmation or operation facts; host `effective_config` remains `not_applicable` until the corresponding extension is adopted.
+
+For `tools/call`, observation begins before tool lookup, name validation, and Zod validation. Each scope ends in `finally`, after response shaping and before transport. End results use this precedence:
+
+1. `handler_error`: an error escapes the handler.
+2. `tool_error`: the direct result has `isError: true`.
+3. `input_required`: the response requests input.
+4. `declined` or `cancelled`: a terminal decline or cancel was consumed.
+5. `completed`: none of the above applies.
+
+The existing `resources/read` catch returns `isError: true`, so that path ends as `tool_error`. An escaping serialization error ends as `handler_error`.
+
+Each retry or replay is a new attempt. There is no deduplication, flow identifier, cross-request state, abandonment timer, or abort-derived end result. `completed` describes handler completion, not completion of a multi-request confirmation flow.
+
+### Durations
+
+Handler `durationMs` uses a monotonic clock from handler entry through response shaping. It excludes SDK pre-entry validation, human wait between attempts, and transport. Timestamps are taken before the corresponding sink work.
+
+Operation durations cover actual awaited protected calls, not the whole confirmation flow. `returned` does not prove readiness or commit; `threw` does not prove that nothing committed.
+
+## Tool-recorded facts: cost confirmation
+
+`ConfirmationFeature` contains only `cost`, and every fact has `feature: 'cost'`. Custom tools can record the full cost fact vocabulary; built-in Supabase cost instrumentation is not available.
+
+| `kind` | Fields and values |
+| --- | --- |
+| `confirmation_decision` | `route: inline \| legacy \| bypass \| blocked`; `reason: eligible \| not_configured \| capability_missing \| read_only \| zero_cost` |
+| `input_required` | `mode: form`; `reason: initial \| missing_response \| changed_quote` |
+| `input_response` | `action: accept \| decline \| cancel` |
+| `resume_validation` | `result: valid \| missing_response \| tool_mismatch \| arguments_mismatch \| changed_quote` |
+| `operation` | `disposition: started` |
+| `operation` | `disposition: returned \| threw`; `durationMs: number` |
+## Failure isolation and disabled behavior
+
+With no observer, there is no scope, context, fact, clock, or Promise work. Guards and forwarding of `undefined` remain. If a configured factory returns `undefined`, the initial timestamp and context have already been created, but no subsequent facts, timing, or recorder are created for that scope.
+
+The safe wrapper catches factory failures, `record` and `end` property access or call failures, and rejection-attachment failures. It never awaits, retries, or logs sink failures. The internal helper ignores late facts and duplicate `end` calls; tools are not exposed to `end`. This is not an exactly-once delivery guarantee.
+
+Rejection handling uses a private intrinsic `Promise.prototype.then.call(Promise.resolve(value), undefined, drop)`, bypassing an individual Promise's own `catch` or `then` overrides. This is failure isolation, not a sandbox: global Promise tampering and hostile constructor or species access are outside the guarantee. A blocking synchronous sink cannot be preempted.
+
+## Privacy and host responsibilities
+
+Observer DTOs contain finite literal values and numeric durations only. They exclude raw arguments, results, SQL, errors, messages, URLs, state, hashes, identifiers, `_meta`, client details, configuration, PII, and baggage.
+
+The existing raw `onToolCall` callback is unchanged and is not certified privacy-safe by this contract.
+
+Hosts control any local collection, configuration, privacy policy, access, retention, and loss handling. None is enabled here. Hosts must not interpret missing observations as proof that an action did not occur.
+

--- a/packages/mcp-utils/src/index.ts
+++ b/packages/mcp-utils/src/index.ts
@@ -1,3 +1,13 @@
 export * from './server.js';
 export * from './stream-transport.js';
 export * from './types.js';
+export type {
+  ConfirmationFeature,
+  ObservationContext,
+  ObservationEnd,
+  ObservationFact,
+  ObservedMethod,
+  ObservedTool,
+  RequestObservation,
+  RequestObserver,
+} from './observation.js';

--- a/packages/mcp-utils/src/observation-noninterference.test.ts
+++ b/packages/mcp-utils/src/observation-noninterference.test.ts
@@ -1,0 +1,181 @@
+import { setImmediate } from 'node:timers/promises';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type {
+  ObservationFact,
+  RequestObservation,
+  RequestObserver,
+} from './observation.js';
+import { action, capture, handlers } from './observation-test-helpers.js';
+
+const decline: ObservationFact = {
+  kind: 'input_response',
+  feature: 'cost',
+  action: 'decline',
+};
+const failure = new Error('PRIVATE_ERROR_SENTINEL');
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('observer noninterference', () => {
+  test.each(['factory', 'record', 'end', 'pending'] as const)(
+    '%s failure preserves callback ordering, business returns and execution errors',
+    async (mode) => {
+      const order: string[] = [];
+      const callback = vi.fn<(details: unknown) => void>(() => {
+        order.push('callback');
+      });
+      const observer: RequestObserver = () => {
+        if (mode === 'factory') throw failure;
+        return {
+          record() {
+            order.push('record');
+            if (mode === 'record') throw failure;
+            if (mode === 'pending') return new Promise<void>(() => {});
+          },
+          end() {
+            order.push('end');
+            if (mode === 'end') throw failure;
+            if (mode === 'pending') return new Promise<void>(() => {});
+          },
+        };
+      };
+      const run = handlers({
+        observer,
+        onToolCall: callback,
+        tools: {
+          good: action(async (_args, _ctx, record) => {
+            record?.({
+              kind: 'operation',
+              feature: 'cost',
+              disposition: 'started',
+            });
+            order.push('execute');
+            return { privateResult: 'unchanged' };
+          }),
+          bad: action(async (_args, _ctx, record) => {
+            record?.({
+              kind: 'operation',
+              feature: 'cost',
+              disposition: 'started',
+            });
+            order.push('execute');
+            throw failure;
+          }),
+        },
+      });
+      expect(await run('tools/call', { name: 'good' })).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ privateResult: 'unchanged' }),
+          },
+        ],
+      });
+      expect(await run('tools/call', { name: 'bad' })).toEqual({
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              error: { name: failure.name, message: failure.message },
+            }),
+          },
+        ],
+      });
+      expect(order).toEqual(
+        mode === 'factory'
+          ? ['execute', 'callback', 'execute', 'callback']
+          : [
+              'record',
+              'execute',
+              'callback',
+              'end',
+              'record',
+              'execute',
+              'callback',
+              'end',
+            ]
+      );
+      expect(callback.mock.calls[0]![0]).toMatchObject({
+        success: true,
+        data: { privateResult: 'unchanged' },
+      });
+      expect(callback.mock.calls[1]![0]).toMatchObject({
+        success: false,
+        error: failure,
+      });
+    }
+  );
+
+  test('resources/read error serialization failure ends as handler_error', async () => {
+    const seen = capture();
+    const run = handlers({
+      observer: seen.observer,
+      resources: () => {
+        throw { message: 1n };
+      },
+    });
+    await expect(
+      run('resources/read', { uri: 'test://a' })
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(seen.scopes[0]!.ends).toEqual([
+      { result: 'handler_error', durationMs: expect.any(Number) },
+    ]);
+  });
+});
+
+test.each(['factory', 'record', 'end'] as const)(
+  'a rejected native promise with hostile own attachment getters from %s is consumed',
+  async (stage) => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (error: unknown) => {
+      unhandled.push(error);
+    };
+    const getter = vi.fn(() => {
+      throw failure;
+    });
+    function rejected() {
+      const promise = Promise.reject(failure);
+      Object.defineProperties(promise, {
+        catch: { get: getter },
+        then: { get: getter },
+      });
+      return promise;
+    }
+    const observer: RequestObserver = () => {
+      // Unsupported async factory deliberately returned by a JS consumer.
+      if (stage === 'factory')
+        return rejected() as unknown as RequestObservation;
+      return {
+        record() {
+          if (stage === 'record') return rejected();
+        },
+        end() {
+          if (stage === 'end') return rejected();
+        },
+      };
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const run = handlers({
+        observer,
+        tools: {
+          test: action(async (_args, _ctx, record) => {
+            record?.(decline);
+            return { unchanged: true };
+          }),
+        },
+      });
+      expect(await run('tools/call', { name: 'test' })).toEqual({
+        content: [{ type: 'text', text: JSON.stringify({ unchanged: true }) }],
+      });
+      // Cross a real event-loop boundary so Node can report unhandled rejections;
+      // no elapsed-time delay is used to guess at completion.
+      await setImmediate();
+      expect(unhandled).toEqual([]);
+      expect(getter).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  }
+);

--- a/packages/mcp-utils/src/observation-test-helpers.ts
+++ b/packages/mcp-utils/src/observation-test-helpers.ts
@@ -1,0 +1,71 @@
+import { Server, type ServerContext } from '@modelcontextprotocol/server';
+import { vi } from 'vitest';
+import { z } from 'zod/v4';
+import type {
+  ObservationContext,
+  ObservationEnd,
+  ObservationFact,
+  RequestObserver,
+} from './observation.js';
+import {
+  createMcpServer,
+  type McpServerOptions,
+  type Tool,
+  tool,
+} from './server.js';
+
+export function capture() {
+  const scopes: {
+    context: ObservationContext;
+    facts: ObservationFact[];
+    ends: ObservationEnd[];
+  }[] = [];
+  const observer: RequestObserver = (context) => {
+    const scope = {
+      context,
+      facts: [] as ObservationFact[],
+      ends: [] as ObservationEnd[],
+    };
+    scopes.push(scope);
+    return {
+      record(fact) {
+        scope.facts.push(fact);
+      },
+      end(end) {
+        scope.ends.push(end);
+      },
+    };
+  };
+  return { observer, scopes };
+}
+
+// Exercise the registered package handler, before the SDK's result validator.
+// This is needed for deliberately unserializable returns and error serialization.
+export function handlers(options: Partial<McpServerOptions> = {}) {
+  const registration = vi.spyOn(Server.prototype, 'setRequestHandler');
+  createMcpServer({ name: 'test', version: '1', ...options });
+  // The package uses only the two-argument registration overload.
+  type Handler = (
+    request: unknown,
+    ctx: ServerContext
+  ) => unknown | Promise<unknown>;
+  const calls = registration.mock.calls as unknown as [string, Handler][];
+  const registered = Object.fromEntries(calls);
+  registration.mockRestore();
+  return async (method: string, params: Record<string, unknown> = {}) => {
+    const handler = registered[method];
+    if (!handler) throw new Error(`Handler not registered: ${method}`);
+    // Each request below supplies the params for its method; SDK validation is
+    // tested separately through the real transport in server-observation-sdk.test.ts.
+    return handler({ method, params }, {} as ServerContext);
+  };
+}
+
+export function action(execute: Tool['execute']) {
+  return tool({
+    description: 'test',
+    parameters: z.object({}),
+    outputSchema: z.looseObject({}),
+    execute,
+  });
+}

--- a/packages/mcp-utils/src/observation.test.ts
+++ b/packages/mcp-utils/src/observation.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  beginObservation,
+  type ObservationContext,
+  type ObservationEnd,
+  type ObservationFact,
+  type RequestObservation,
+  type RequestObserver,
+} from './observation.js';
+
+const context: ObservationContext = {
+  method: 'tools/call',
+  tool: 'create_project',
+};
+const decline: ObservationFact = {
+  kind: 'input_response',
+  feature: 'cost',
+  action: 'decline',
+};
+const completed: ObservationEnd = { result: 'completed', durationMs: 0 };
+const failure = new Error('PRIVATE_ERROR_SENTINEL');
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('safe observation scope', () => {
+  test('first end closes even when the sink throws; duplicates and late facts are inert', () => {
+    const record = vi.fn();
+    const end = vi.fn(() => {
+      throw failure;
+    });
+    const scope = beginObservation(() => ({ record, end }), context)!;
+    scope.record(decline);
+    scope.record(decline);
+    expect(scope.consumedTerminal()).toBe('declined');
+    scope.end(completed);
+    scope.end({ result: 'handler_error', durationMs: 12 });
+    scope.record({ kind: 'input_response', feature: 'cost', action: 'accept' });
+    expect(record.mock.calls).toEqual([[decline], [decline]]);
+    expect(end.mock.calls).toEqual([[completed]]);
+    expect(scope.consumedTerminal()).toBe('declined');
+  });
+
+  test.each([
+    'throw',
+    'reject',
+    'then-getter',
+    'then-throw',
+    'pending',
+  ] as const)(
+    'contains %s from both record and end without waiting or logging',
+    async (mode) => {
+      const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+      let calls = 0;
+      const hostile = () => {
+        calls++;
+        if (mode === 'throw') throw failure;
+        if (mode === 'reject') return Promise.reject(failure);
+        if (mode === 'pending') return new Promise<void>(() => {});
+        if (mode === 'then-getter')
+          return Object.defineProperty({}, 'then', {
+            get() {
+              throw failure;
+            },
+          });
+        return {
+          then() {
+            throw failure;
+          },
+        };
+      };
+      // Deliberately exercise JS consumers outside the declared return type.
+      const sink = {
+        record: hostile,
+        end: hostile,
+      } as unknown as RequestObservation;
+      const scope = beginObservation(() => sink, context)!;
+      scope.record(decline);
+      scope.end(completed);
+      // Let native promise adoption and its rejection handler run.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls).toBe(2);
+      expect(scope.consumedTerminal()).toBe('declined');
+      expect(log).not.toHaveBeenCalled();
+    }
+  );
+
+  test('throwing sink getters do not prevent terminal action tracking or closing', () => {
+    const accesses: string[] = [];
+    const sink: RequestObservation = {
+      get record(): RequestObservation['record'] {
+        accesses.push('record');
+        throw failure;
+      },
+      get end(): RequestObservation['end'] {
+        accesses.push('end');
+        throw failure;
+      },
+    };
+    const scope = beginObservation(() => sink, context)!;
+    scope.record(decline);
+    scope.end(completed);
+    scope.record(decline);
+    scope.end(completed);
+    expect(accesses).toEqual(['record', 'end']);
+    expect(scope.consumedTerminal()).toBe('declined');
+  });
+
+  test('factory throws, undefined, promises and throwing then getters disable the scope', async () => {
+    const factories = [
+      () => {
+        throw failure;
+      },
+      () => undefined,
+      () => Promise.reject(failure),
+      () => new Promise(() => {}),
+      () =>
+        Object.defineProperty({}, 'then', {
+          get() {
+            throw failure;
+          },
+        }),
+    ];
+    for (const factory of factories) {
+      expect(
+        beginObservation(factory as RequestObserver, context)
+      ).toBeUndefined();
+    }
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/packages/mcp-utils/src/observation.ts
+++ b/packages/mcp-utils/src/observation.ts
@@ -1,0 +1,219 @@
+/**
+ * Payload-free observations for MCP handler attempts and shipped cost confirmation.
+ * These types do not describe transport delivery, consent, or backend commit.
+ */
+
+export type ObservedMethod =
+  | 'tools/call'
+  | 'tools/list'
+  | 'resources/list'
+  | 'resources/templates/list'
+  | 'resources/read';
+
+export type ObservedTool =
+  | 'create_project'
+  | 'create_branch'
+  | 'execute_sql'
+  | 'apply_migration'
+  | 'other'
+  | 'not_applicable';
+
+export type ObservationContext = Readonly<{
+  method: ObservedMethod;
+  tool: ObservedTool;
+}>;
+
+export type ConfirmationFeature = 'cost';
+
+export type ObservationFact =
+  | Readonly<{
+      kind: 'confirmation_decision';
+      feature: ConfirmationFeature;
+      route: 'inline' | 'legacy' | 'bypass' | 'blocked';
+      reason:
+        | 'eligible'
+        | 'not_configured'
+        | 'capability_missing'
+        | 'read_only'
+        | 'zero_cost';
+    }>
+  | Readonly<{
+      kind: 'input_required';
+      feature: ConfirmationFeature;
+      mode: 'form';
+      reason: 'initial' | 'missing_response' | 'changed_quote';
+    }>
+  | Readonly<{
+      kind: 'input_response';
+      feature: ConfirmationFeature;
+      action: 'accept' | 'decline' | 'cancel';
+    }>
+  | Readonly<{
+      kind: 'resume_validation';
+      feature: ConfirmationFeature;
+      result:
+        | 'valid'
+        | 'missing_response'
+        | 'tool_mismatch'
+        | 'arguments_mismatch'
+        | 'changed_quote';
+    }>
+  | Readonly<{
+      kind: 'operation';
+      feature: 'cost';
+      disposition: 'started';
+    }>
+  | Readonly<{
+      kind: 'operation';
+      feature: 'cost';
+      disposition: 'returned' | 'threw';
+      durationMs: number;
+    }>;
+
+export type ObservationEnd = Readonly<{
+  result:
+    | 'completed'
+    | 'input_required'
+    | 'declined'
+    | 'cancelled'
+    | 'tool_error'
+    | 'handler_error';
+  durationMs: number;
+}>;
+
+export type RequestObservation = Readonly<{
+  record(fact: ObservationFact): void | Promise<void>;
+  end(result: ObservationEnd): void | Promise<void>;
+}>;
+
+export type RequestObserver = (
+  context: ObservationContext
+) => RequestObservation | undefined;
+
+/**
+ * Terminal disposition implied by the most recently recorded consumed
+ * action, when the handler otherwise returns without an explicit outcome
+ * (no thrown/handler error, no `isError` result, no input-required round).
+ * `undefined` when the last consumed action was not a decline/cancel, or no
+ * action has been recorded yet.
+ */
+type ConsumedTerminal = 'declined' | 'cancelled' | undefined;
+
+/**
+ * Package-internal handle wrapping a host-supplied {@link RequestObservation}
+ * with failure isolation. Not part of the public contract: hosts never see
+ * this type, only the plain `record`/`end` shape they implement.
+ */
+export type ObservationScope = Readonly<{
+  record(fact: ObservationFact): void;
+  end(result: ObservationEnd): void;
+  /**
+   * Reads the terminal disposition implied by the last consumed
+   * decline/cancel action, for handlers that otherwise return an ordinary
+   * result. Callers must apply error precedence themselves: this is only
+   * consulted on an otherwise-ordinary return, never after a thrown or
+   * `isError` result.
+   */
+  consumedTerminal(): ConsumedTerminal;
+}>;
+
+/**
+ * Begins an observation scope for one handler entry.
+ *
+ * Factory and sink failures are contained and never awaited or logged.
+ * Unsupported asynchronous factories are discarded, consuming their rejection.
+ * Synchronous callbacks can still block; this is not a CPU sandbox.
+ */
+export function beginObservation(
+  observer: RequestObserver,
+  context: ObservationContext
+): ObservationScope | undefined {
+  let observation: RequestObservation | undefined;
+
+  try {
+    const created = observer(context);
+
+    if (created instanceof Promise || isThenable(created)) {
+      // A synchronous factory returning a runtime Promise is unsupported.
+      // Never await it; just consume any rejection and discard the scope.
+      Promise.prototype.then.call(Promise.resolve(created), undefined, drop);
+      return undefined;
+    }
+
+    observation = created;
+  } catch {
+    // Factory failure disables this scope; it must never affect the caller.
+    return undefined;
+  }
+
+  if (!observation) {
+    return undefined;
+  }
+
+  const sink = observation;
+  let ended = false;
+  let consumedTerminal: ConsumedTerminal;
+
+  return {
+    record(fact: ObservationFact): void {
+      // Reject late facts: once ended, this scope is inert.
+      if (ended) {
+        return;
+      }
+
+      if (fact.kind === 'input_response') {
+        consumedTerminal =
+          fact.action === 'decline'
+            ? 'declined'
+            : fact.action === 'cancel'
+              ? 'cancelled'
+              : undefined;
+      }
+
+      safeCall(() => sink.record(fact));
+    },
+    end(result: ObservationEnd): void {
+      // First end wins; duplicate end is a silent no-op, not a failure.
+      if (ended) {
+        return;
+      }
+      ended = true;
+
+      safeCall(() => sink.end(result));
+    },
+    consumedTerminal(): ConsumedTerminal {
+      return consumedTerminal;
+    },
+  };
+}
+
+/**
+ * Calls `action`, swallowing any synchronous throw (including a throwing
+ * property getter reached while evaluating `action`) and consuming any
+ * rejection from a returned thenable without ever awaiting it.
+ */
+function safeCall(action: () => void | Promise<void>): void {
+  try {
+    const result = action();
+
+    if (result !== undefined) {
+      // Bypass sink-owned catch/then overrides on native promises.
+      Promise.prototype.then.call(Promise.resolve(result), undefined, drop);
+    }
+  } catch {
+    // Telemetry-only failure: never surface, retry, or log the raw value.
+  }
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  if (
+    value === null ||
+    (typeof value !== 'object' && typeof value !== 'function')
+  ) {
+    return false;
+  }
+
+  return 'then' in value && typeof value.then === 'function';
+}
+
+function drop(): void {}

--- a/packages/mcp-utils/src/server-observation-sdk.test.ts
+++ b/packages/mcp-utils/src/server-observation-sdk.test.ts
@@ -1,0 +1,186 @@
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from '@modelcontextprotocol/client';
+import {
+  createMcpHandler,
+  createRequestStateCodec,
+  type JSONRPCMessage,
+  type Server,
+} from '@modelcontextprotocol/server';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { z } from 'zod/v4';
+import { createMcpServer, tool } from './server.js';
+import { StreamTransport } from './stream-transport.js';
+
+const MCP_CLIENT_NAME = 'test-client';
+const MCP_CLIENT_VERSION = '0.1.0';
+const clients: Client[] = [];
+const pipes: Promise<PromiseSettledResult<void>[]>[] = [];
+
+afterEach(async () => {
+  try {
+    await Promise.all(clients.splice(0).map((client) => client.close()));
+    for (const pending of pipes.splice(0)) {
+      await pending;
+    }
+  } finally {
+    vi.restoreAllMocks();
+  }
+});
+
+async function setup(options: { server: Server }) {
+  const { server } = options;
+  const clientTransport = new StreamTransport();
+  const serverTransport = new StreamTransport();
+
+  pipes.push(
+    Promise.allSettled([
+      clientTransport.readable.pipeTo(serverTransport.writable),
+      serverTransport.readable.pipeTo(clientTransport.writable),
+    ])
+  );
+
+  const client = new Client(
+    {
+      name: MCP_CLIENT_NAME,
+      version: MCP_CLIENT_VERSION,
+    },
+    {
+      capabilities: {},
+    }
+  );
+
+  clients.push(client);
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, clientTransport };
+}
+
+describe('observer SDK boundary', () => {
+  test('initialization, notifications, malformed calls and unknown methods do not enter a scope', async () => {
+    const observer = vi.fn(() => ({ record() {}, end() {} }));
+    const execute = vi.fn(async () => ({}));
+    const server = createMcpServer({
+      name: 'test',
+      version: '1',
+      observer,
+      tools: {
+        test: tool({
+          description: 'test',
+          parameters: z.object({}),
+          outputSchema: z.object({}),
+          execute,
+        }),
+      },
+    });
+    const { clientTransport, client } = await setup({ server });
+    expect(observer).not.toHaveBeenCalled();
+
+    let id = 900;
+    for (const request of [
+      { method: 'tools/call', params: { name: 42 } },
+      { method: 'private/unknown', params: {} },
+    ]) {
+      const requestId = id++;
+      const previous = clientTransport.onmessage;
+      // Bypass the client's outbound validator to reach real SDK prevalidation.
+      // Node 20 has no Promise.withResolvers.
+      const response = new Promise<JSONRPCMessage>((resolve) => {
+        clientTransport.onmessage = (message) => {
+          if ('id' in message && message.id === requestId) resolve(message);
+          else previous?.(message);
+        };
+      });
+      await clientTransport.send({ jsonrpc: '2.0', id: requestId, ...request });
+      expect(await response).toMatchObject({
+        error: { code: request.method === 'tools/call' ? -32602 : -32601 },
+      });
+      clientTransport.onmessage = previous;
+    }
+    expect(observer).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+    await client.callTool({ name: 'test' });
+    expect(observer).toHaveBeenCalledTimes(1);
+    expect(observer).toHaveBeenCalledWith({
+      method: 'tools/call',
+      tool: 'other',
+    });
+  });
+
+  test.each(['signature', 'expired'] as const)(
+    '%s rejection has no producer scope on the modern SDK wire',
+    async (mode) => {
+      // Public synthetic test key, never an application credential.
+      const codec = createRequestStateCodec({
+        key: 'observer-test-key'.repeat(3),
+        ttlSeconds: mode === 'expired' ? -1 : 600,
+      });
+      const state = await codec.mint({ fixture: true });
+      const dot = state.lastIndexOf('.');
+      const macFirst = state[dot + 1];
+      const rejectedState =
+        mode === 'expired'
+          ? state
+          : state.slice(0, dot + 1) +
+            (macFirst === 'a' ? 'b' : 'a') +
+            state.slice(dot + 2);
+      const observer = vi.fn(() => ({ record() {}, end() {} }));
+      const execute = vi.fn(async () => ({}));
+      const handler = createMcpHandler(() =>
+        createMcpServer({
+          name: 'test',
+          version: '1',
+          observer,
+          requestState: { verify: codec.verify },
+          tools: {
+            test: tool({
+              description: 'test',
+              parameters: z.object({}),
+              outputSchema: z.object({}),
+              execute,
+            }),
+          },
+        })
+      );
+      const client = new Client(
+        { name: 'test', version: '1' },
+        {
+          versionNegotiation: { mode: { pin: '2026-07-28' } },
+          inputRequired: { autoFulfill: false },
+        }
+      );
+      clients.push(client);
+      await client.connect(
+        new StreamableHTTPClientTransport(
+          new URL('http://observer.invalid/mcp'),
+          {
+            fetch: (url, init) => handler.fetch(new Request(url, init)),
+          }
+        )
+      );
+      await expect(
+        client.request(
+          {
+            method: 'tools/call',
+            params: {
+              name: 'test',
+              requestState: rejectedState,
+              inputResponses: { confirm: { action: 'accept', content: {} } },
+            },
+          },
+          { allowInputRequired: true }
+        )
+      ).rejects.toMatchObject({ code: -32602 });
+      expect(observer).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+      await client.request({ method: 'tools/call', params: { name: 'test' } });
+      expect(observer).toHaveBeenCalledTimes(1);
+      expect(observer).toHaveBeenCalledWith({
+        method: 'tools/call',
+        tool: 'other',
+      });
+    }
+  );
+});

--- a/packages/mcp-utils/src/server-observation.test.ts
+++ b/packages/mcp-utils/src/server-observation.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { z } from 'zod/v4';
+import type { ObservationFact, RequestObserver } from './observation.js';
+import { type Tool, tool } from './server.js';
+import { action, capture, handlers } from './observation-test-helpers.js';
+
+const decline: ObservationFact = {
+  kind: 'input_response',
+  feature: 'cost',
+  action: 'decline',
+};
+const failure = new Error('PRIVATE_ERROR_SENTINEL');
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('registered handler observations', () => {
+  test('all five scopes include shaping, bound context, and exclude end sink latency', async () => {
+    const seen = capture();
+    let now = 0;
+    const clock = vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const observer: RequestObserver = (context) => {
+      now += 2;
+      const sink = seen.observer(context)!;
+      return {
+        record: sink.record,
+        end(end) {
+          sink.end(end);
+          now += 100;
+        },
+      };
+    };
+    const run = handlers({
+      observer,
+      tools: {
+        private_tool_name: action(async () => ({
+          toJSON() {
+            now += 3;
+            return { ok: true };
+          },
+        })),
+      },
+      resources: [
+        {
+          uri: 'test://private',
+          name: 'PRIVATE_NAME',
+          async read() {
+            return { uri: 'test://private', text: 'PRIVATE_RESULT' };
+          },
+        },
+        {
+          uriTemplate: 'test://{id}',
+          name: 'PRIVATE_TEMPLATE',
+          async read() {
+            return [];
+          },
+        },
+      ],
+    });
+    await run('tools/list');
+    await run('resources/list');
+    await run('resources/templates/list');
+    await run('resources/read', { uri: 'test://private' });
+    await run('tools/call', { name: 'private_tool_name' });
+    expect(seen.scopes.map(({ context, ends }) => ({ context, ends }))).toEqual(
+      [
+        ...[
+          'tools/list',
+          'resources/list',
+          'resources/templates/list',
+          'resources/read',
+        ].map((method) => ({
+          context: { method, tool: 'not_applicable' },
+          ends: [{ result: 'completed', durationMs: 2 }],
+        })),
+        {
+          context: { method: 'tools/call', tool: 'other' },
+          ends: [{ result: 'completed', durationMs: 5 }],
+        },
+      ]
+    );
+    expect(clock).toHaveBeenCalledTimes(10);
+    expect(JSON.stringify(seen.scopes)).not.toContain('PRIVATE');
+    expect(JSON.stringify(seen.scopes)).not.toContain('private_tool_name');
+  });
+
+  test.each(['omitted', 'undefined'] as const)(
+    '%s observer avoids recorder, facts and subsequent clocks',
+    async (mode) => {
+      const clock = vi.spyOn(performance, 'now').mockReturnValue(0);
+      let constructed = 0;
+      const run = handlers({
+        observer: mode === 'undefined' ? () => undefined : undefined,
+        tools: {
+          create_project: action(async (_args, _ctx, record) => {
+            record?.((constructed++, decline));
+            return { ok: true };
+          }),
+        },
+        resources: [
+          {
+            uri: 'test://a',
+            name: 'a',
+            async read() {
+              return [];
+            },
+          },
+        ],
+      });
+      await run('tools/call', { name: 'create_project' });
+      await run('tools/list');
+      await run('resources/list');
+      await run('resources/templates/list');
+      await run('resources/read', { uri: 'test://a' });
+      expect(constructed).toBe(0);
+      expect(clock).toHaveBeenCalledTimes(mode === 'omitted' ? 0 : 5);
+    }
+  );
+
+  test.each([
+    { action: 'accept', value: { ok: true }, result: 'completed' },
+    { action: 'decline', value: { ok: true }, result: 'declined' },
+    { action: 'cancel', value: { content: [] }, result: 'cancelled' },
+    {
+      action: 'decline',
+      value: { resultType: 'input_required' },
+      result: 'input_required',
+    },
+    {
+      action: 'cancel',
+      value: { content: [], isError: true },
+      result: 'tool_error',
+    },
+    {
+      action: 'decline',
+      value: { resultType: 'input_required', isError: true },
+      result: 'tool_error',
+    },
+  ] as const)(
+    'terminal $result takes precedence after consumed $action',
+    async (row) => {
+      const seen = capture();
+      vi.spyOn(performance, 'now').mockReturnValue(0);
+      const run = handlers({
+        observer: seen.observer,
+        tools: {
+          create_branch: action(async (_args, _ctx, record) => {
+            record?.({
+              kind: 'input_response',
+              feature: 'cost',
+              action: row.action,
+            });
+            // Malformed combinations deliberately test package shaping, not SDK DTO validation.
+            return row.value as never;
+          }),
+        },
+      });
+      expect(await run('tools/call', { name: 'create_branch' })).toEqual(
+        'content' in row.value || 'resultType' in row.value
+          ? row.value
+          : { content: [{ type: 'text', text: JSON.stringify(row.value) }] }
+      );
+      expect(seen.scopes[0]!.ends).toEqual([
+        { result: row.result, durationMs: 0 },
+      ]);
+    }
+  );
+
+  test.each([
+    'getTools',
+    'name',
+    'parse',
+    'execute',
+    'serialization',
+    'error-serialization',
+  ] as const)(
+    'starts before %s failure and closes once with error precedence',
+    async (stage) => {
+      const seen = capture();
+      const callback = vi.fn();
+      const cyclic: Record<string, unknown> = {};
+      cyclic.self = cyclic;
+      const execute = vi.fn<Tool['execute']>(async (_args, _ctx, record) => {
+        record?.(decline);
+        if (stage === 'execute') throw failure;
+        if (stage === 'serialization') return cyclic;
+        if (stage === 'error-serialization') throw { message: 1n };
+        return {};
+      });
+      const tools = {
+        create_project: tool({
+          description: 'test',
+          parameters: z.object({ required: z.string() }),
+          outputSchema: z.looseObject({}),
+          execute,
+        }),
+      };
+      const run = handlers({
+        observer: seen.observer,
+        onToolCall: callback,
+        tools: () => {
+          expect(seen.scopes.map((scope) => scope.context)).toEqual([
+            {
+              method: 'tools/call',
+              tool: stage === 'name' ? 'other' : 'create_project',
+            },
+          ]);
+          if (stage === 'getTools') throw failure;
+          return tools;
+        },
+      });
+      const request = run('tools/call', {
+        name: stage === 'name' ? 'missing' : 'create_project',
+        arguments: stage === 'parse' ? {} : { required: 'PRIVATE_ARGUMENT' },
+      });
+      if (stage === 'error-serialization')
+        await expect(request).rejects.toBeInstanceOf(TypeError);
+      else expect(await request).toMatchObject({ isError: true });
+      expect(seen.scopes[0]!.ends).toEqual([
+        {
+          result:
+            stage === 'error-serialization' ? 'handler_error' : 'tool_error',
+          durationMs: expect.any(Number),
+        },
+      ]);
+      expect(callback).toHaveBeenCalledTimes(
+        ['getTools', 'name', 'parse'].includes(stage) ? 0 : 1
+      );
+      expect(JSON.stringify(seen.scopes)).not.toContain('PRIVATE');
+    }
+  );
+
+  test.each([
+    'tools/list',
+    'resources/list',
+    'resources/templates/list',
+    'resources/read',
+  ] as const)(
+    '%s records its existing failure behavior without manufacturing success',
+    async (method) => {
+      const seen = capture();
+      const run = handlers({
+        observer: seen.observer,
+        tools: () => {
+          throw failure;
+        },
+        resources: () => {
+          throw failure;
+        },
+      });
+      const result = run(method, { uri: 'test://a' });
+      if (method === 'resources/read')
+        expect(await result).toMatchObject({ isError: true });
+      else await expect(result).rejects.toBe(failure);
+      expect(seen.scopes[0]!.ends).toEqual([
+        {
+          result: method === 'resources/read' ? 'tool_error' : 'handler_error',
+          durationMs: expect.any(Number),
+        },
+      ]);
+    }
+  );
+
+  test('reverse completion, replay and late recorders do not cross scopes', async () => {
+    const seen = capture();
+    const pending: {
+      finish: () => void;
+      record: ((fact: ObservationFact) => void) | undefined;
+    }[] = [];
+    // Node 20 is supported and does not provide Promise.withResolvers.
+    const run = handlers({
+      observer: seen.observer,
+      tools: {
+        create_project: action(async (_args, _ctx, record) => {
+          await new Promise<void>((resolve) => {
+            pending.push({ finish: resolve, record });
+          });
+          return { ok: true };
+        }),
+      },
+    });
+    const first = run('tools/call', { name: 'create_project' });
+    const second = run('tools/call', { name: 'create_project' });
+    // getTools is awaited before each execute.
+    await Promise.resolve();
+    pending[1]!.record?.({
+      kind: 'input_response',
+      feature: 'cost',
+      action: 'cancel',
+    });
+    pending[1]!.finish();
+    await second;
+    pending[0]!.record?.(decline);
+    pending[0]!.finish();
+    await first;
+    pending[1]!.record?.(decline);
+    const replay = run('tools/call', { name: 'create_project' });
+    await Promise.resolve();
+    pending[2]!.finish();
+    await replay;
+    expect(
+      seen.scopes.map((scope) => scope.ends.map((end) => end.result))
+    ).toEqual([['declined'], ['cancelled'], ['completed']]);
+    expect(seen.scopes.map((scope) => scope.facts)).toEqual([
+      [decline],
+      [{ kind: 'input_response', feature: 'cost', action: 'cancel' }],
+      [],
+    ]);
+  });
+});

--- a/packages/mcp-utils/src/server.ts
+++ b/packages/mcp-utils/src/server.ts
@@ -16,6 +16,14 @@ import { z } from 'zod/v4';
 
 import type { ExtractParams } from './types.js';
 import { assertValidUri, compareUris, matchUriTemplate } from './util.js';
+import { beginObservation } from './observation.js';
+import type {
+  ObservationEnd,
+  ObservationFact,
+  ObservationScope,
+  ObservedTool,
+  RequestObserver,
+} from './observation.js';
 
 export type Scheme = string;
 export type Annotations = NonNullable<
@@ -64,10 +72,17 @@ export type Tool<
    * passed straight to the client instead of being JSON-wrapped; any other
    * value is wrapped as today (`{ content: [{ type: 'text', text:
    * JSON.stringify(value) }] }`).
+   *
+   * The optional third `record` argument is a safe, synchronous recorder
+   * for {@link ObservationFact}s tied to this call's observation scope.
+   * It is `undefined` whenever no observer is configured for this server;
+   * it never throws back into the tool and never returns a promise the
+   * tool needs to handle.
    */
   execute(
     params: z.infer<Params>,
-    ctx: ServerContext
+    ctx: ServerContext,
+    record?: (fact: ObservationFact) => void
   ): Promise<z.infer<OutputSchema> | InputRequiredResult | CallToolResult>;
 };
 
@@ -289,7 +304,33 @@ export type McpServerOptions = {
   requestState?: {
     verify?: (state: string, ctx: ServerContext) => unknown | Promise<unknown>;
   };
+
+  /**
+   * Optional per-request observation factory for lightweight, payload-free
+   * lifecycle instrumentation. Invoked synchronously at most once per
+   * registered handler entry (`tools/call`, `tools/list`, `resources/list`,
+   * `resources/templates/list`, `resources/read`); its return value is
+   * never awaited. Omitting it disables observation entirely: no context
+   * object, clock read, or fact is ever produced.
+   */
+  observer?: RequestObserver;
 };
+
+/**
+ * Normalizes a raw tool name to the closed {@link ObservedTool} allowlist.
+ * Unlisted tools — including any not yet registered — become `'other'`.
+ */
+function normalizeObservedTool(name: string): ObservedTool {
+  switch (name) {
+    case 'create_project':
+    case 'create_branch':
+    case 'execute_sql':
+    case 'apply_migration':
+      return name;
+    default:
+      return 'other';
+  }
+}
 
 /**
  * Creates an MCP server with the given options.
@@ -365,106 +406,178 @@ export function createMcpServer(options: McpServerOptions) {
     server.setRequestHandler(
       'resources/list',
       async (): Promise<ListResourcesResult> => {
-        const allResources = await getResources();
-        return {
-          resources: allResources
-            .filter((resource) => 'uri' in resource)
-            .map(({ uri, name, description, mimeType }) => {
-              return {
-                uri,
-                name,
-                description,
-                mimeType,
-              };
-            }),
-        };
+        let scope: ObservationScope | undefined;
+        let startedAt = 0;
+
+        if (options.observer) {
+          startedAt = performance.now();
+          scope = beginObservation(options.observer, {
+            method: 'resources/list',
+            tool: 'not_applicable',
+          });
+        }
+
+        let outcome: ObservationEnd['result'] = 'completed';
+
+        try {
+          const allResources = await getResources();
+          return {
+            resources: allResources
+              .filter((resource) => 'uri' in resource)
+              .map(({ uri, name, description, mimeType }) => {
+                return {
+                  uri,
+                  name,
+                  description,
+                  mimeType,
+                };
+              }),
+          };
+        } catch (error) {
+          outcome = 'handler_error';
+          throw error;
+        } finally {
+          scope?.end({
+            result: outcome,
+            durationMs: performance.now() - startedAt,
+          });
+        }
       }
     );
 
     server.setRequestHandler(
       'resources/templates/list',
       async (): Promise<ListResourceTemplatesResult> => {
-        const allResources = await getResources();
-        return {
-          resourceTemplates: allResources
-            .filter((resource) => 'uriTemplate' in resource)
-            .map(({ uriTemplate, name, description, mimeType }) => {
-              return {
-                uriTemplate,
-                name,
-                description,
-                mimeType,
-              };
-            }),
-        };
+        let scope: ObservationScope | undefined;
+        let startedAt = 0;
+
+        if (options.observer) {
+          startedAt = performance.now();
+          scope = beginObservation(options.observer, {
+            method: 'resources/templates/list',
+            tool: 'not_applicable',
+          });
+        }
+
+        let outcome: ObservationEnd['result'] = 'completed';
+
+        try {
+          const allResources = await getResources();
+          return {
+            resourceTemplates: allResources
+              .filter((resource) => 'uriTemplate' in resource)
+              .map(({ uriTemplate, name, description, mimeType }) => {
+                return {
+                  uriTemplate,
+                  name,
+                  description,
+                  mimeType,
+                };
+              }),
+          };
+        } catch (error) {
+          outcome = 'handler_error';
+          throw error;
+        } finally {
+          scope?.end({
+            result: outcome,
+            durationMs: performance.now() - startedAt,
+          });
+        }
       }
     );
 
     server.setRequestHandler(
       'resources/read',
       async (request): Promise<ReadResourceResult> => {
+        let scope: ObservationScope | undefined;
+        let startedAt = 0;
+
+        if (options.observer) {
+          startedAt = performance.now();
+          scope = beginObservation(options.observer, {
+            method: 'resources/read',
+            tool: 'not_applicable',
+          });
+        }
+
+        let outcome: ObservationEnd['result'] = 'completed';
+
         try {
-          const allResources = await getResources();
-          const { uri } = request.params;
+          try {
+            const allResources = await getResources();
+            const { uri } = request.params;
 
-          const resources = allResources.filter(
-            (resource) => 'uri' in resource
-          );
-          const resource = resources.find((resource) =>
-            compareUris(resource.uri, uri)
-          );
+            const resources = allResources.filter(
+              (resource) => 'uri' in resource
+            );
+            const resource = resources.find((resource) =>
+              compareUris(resource.uri, uri)
+            );
 
-          if (resource) {
-            const result = await resource.read(uri as `${string}://${string}`);
+            if (resource) {
+              const result = await resource.read(
+                uri as `${string}://${string}`
+              );
+
+              const contents = Array.isArray(result) ? result : [result];
+
+              return {
+                contents,
+              };
+            }
+
+            const resourceTemplates = allResources.filter(
+              (resource) => 'uriTemplate' in resource
+            );
+            const resourceTemplateUris = resourceTemplates.map(
+              ({ uriTemplate }) => assertValidUri(uriTemplate)
+            );
+
+            const templateMatch = matchUriTemplate(uri, resourceTemplateUris);
+
+            if (!templateMatch) {
+              throw new Error('resource not found');
+            }
+
+            const resourceTemplate = resourceTemplates.find(
+              (r) => r.uriTemplate === templateMatch.uri
+            );
+
+            if (!resourceTemplate) {
+              throw new Error('resource not found');
+            }
+
+            const result = await resourceTemplate.read(
+              uri as `${string}://${string}`,
+              templateMatch.params
+            );
 
             const contents = Array.isArray(result) ? result : [result];
 
             return {
               contents,
             };
+          } catch (error) {
+            outcome = 'tool_error';
+            return {
+              isError: true,
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({ error: enumerateError(error) }),
+                },
+              ],
+            } as any;
           }
-
-          const resourceTemplates = allResources.filter(
-            (resource) => 'uriTemplate' in resource
-          );
-          const resourceTemplateUris = resourceTemplates.map(
-            ({ uriTemplate }) => assertValidUri(uriTemplate)
-          );
-
-          const templateMatch = matchUriTemplate(uri, resourceTemplateUris);
-
-          if (!templateMatch) {
-            throw new Error('resource not found');
-          }
-
-          const resourceTemplate = resourceTemplates.find(
-            (r) => r.uriTemplate === templateMatch.uri
-          );
-
-          if (!resourceTemplate) {
-            throw new Error('resource not found');
-          }
-
-          const result = await resourceTemplate.read(
-            uri as `${string}://${string}`,
-            templateMatch.params
-          );
-
-          const contents = Array.isArray(result) ? result : [result];
-
-          return {
-            contents,
-          };
         } catch (error) {
-          return {
-            isError: true,
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({ error: enumerateError(error) }),
-              },
-            ],
-          } as any;
+          outcome = 'handler_error';
+          throw error;
+        } finally {
+          scope?.end({
+            result: outcome,
+            durationMs: performance.now() - startedAt,
+          });
         }
       }
     );
@@ -474,104 +587,172 @@ export function createMcpServer(options: McpServerOptions) {
     server.setRequestHandler(
       'tools/list',
       async (_request, ctx): Promise<ListToolsResult> => {
-        const tools = await getTools(ctx);
+        let scope: ObservationScope | undefined;
+        let startedAt = 0;
 
-        return {
-          tools: await Promise.all(
-            Object.entries(tools)
-              .filter(([, tool]) => !tool.hidden)
-              .map(async ([name, { description, annotations, parameters }]) => {
-                const inputSchema = z.toJSONSchema(parameters, {
-                  target: 'draft-7',
-                });
+        if (options.observer) {
+          startedAt = performance.now();
+          scope = beginObservation(options.observer, {
+            method: 'tools/list',
+            tool: 'not_applicable',
+          });
+        }
 
-                return {
-                  name,
-                  description:
-                    typeof description === 'function'
-                      ? await description()
-                      : description,
-                  annotations,
-                  // Casting the same as the SDK does:
-                  // https://github.com/modelcontextprotocol/typescript-sdk/blob/fb07af810b51003c338dc4885a9e42f54519f9af/src/server/mcp.ts#L154
-                  inputSchema: inputSchema as McpTool['inputSchema'],
-                };
-              })
-          ),
-        } satisfies ListToolsResult;
+        let outcome: ObservationEnd['result'] = 'completed';
+
+        try {
+          const tools = await getTools(ctx);
+
+          return {
+            tools: await Promise.all(
+              Object.entries(tools)
+                .filter(([, tool]) => !tool.hidden)
+                .map(
+                  async ([name, { description, annotations, parameters }]) => {
+                    const inputSchema = z.toJSONSchema(parameters, {
+                      target: 'draft-7',
+                    });
+
+                    return {
+                      name,
+                      description:
+                        typeof description === 'function'
+                          ? await description()
+                          : description,
+                      annotations,
+                      // Casting the same as the SDK does:
+                      // https://github.com/modelcontextprotocol/typescript-sdk/blob/fb07af810b51003c338dc4885a9e42f54519f9af/src/server/mcp.ts#L154
+                      inputSchema: inputSchema as McpTool['inputSchema'],
+                    };
+                  }
+                )
+            ),
+          } satisfies ListToolsResult;
+        } catch (error) {
+          outcome = 'handler_error';
+          throw error;
+        } finally {
+          scope?.end({
+            result: outcome,
+            durationMs: performance.now() - startedAt,
+          });
+        }
       }
     );
 
     server.setRequestHandler('tools/call', async (request, ctx) => {
+      const toolName = request.params.name;
+      let scope: ObservationScope | undefined;
+      let startedAt = 0;
+
+      if (options.observer) {
+        startedAt = performance.now();
+        scope = beginObservation(options.observer, {
+          method: 'tools/call',
+          tool: normalizeObservedTool(toolName),
+        });
+      }
+
+      let outcome: ObservationEnd['result'] = 'completed';
+
       try {
-        const tools = await getTools(ctx);
-        const toolName = request.params.name;
+        try {
+          const tools = await getTools(ctx);
 
-        if (!(toolName in tools)) {
-          throw new Error('tool not found');
-        }
-
-        const tool = tools[toolName];
-
-        if (!tool) {
-          throw new Error('tool not found');
-        }
-        const args = tool.parameters
-          .strict()
-          .parse(request.params.arguments ?? {});
-
-        const executeWithCallback = async (tool: Tool) => {
-          // Wrap success or error in a result value
-          const res = await tool
-            .execute(args, ctx)
-            .then((data: unknown) => ({ success: true as const, data }))
-            .catch((error) => ({ success: false as const, error }));
-
-          try {
-            options.onToolCall?.({
-              name: toolName,
-              arguments: args,
-              annotations: tool.annotations,
-              ...res,
-            });
-          } catch (error) {
-            // Don't fail the tool call if the callback fails
-            console.error('Failed to run tool callback', error);
+          if (!(toolName in tools)) {
+            throw new Error('tool not found');
           }
 
-          // Unwrap result
-          if (!res.success) {
-            throw res.error;
+          const tool = tools[toolName];
+
+          if (!tool) {
+            throw new Error('tool not found');
           }
-          return res.data;
-        };
+          const args = tool.parameters
+            .strict()
+            .parse(request.params.arguments ?? {});
 
-        const result = await executeWithCallback(tool);
+          const executeWithCallback = async (tool: Tool) => {
+            // Wrap success or error in a result value
+            const res = await tool
+              .execute(args, ctx, scope?.record)
+              .then((data: unknown) => ({ success: true as const, data }))
+              .catch((error) => ({ success: false as const, error }));
 
-        // An InputRequiredResult or a direct CallToolResult is already
-        // shaped for the wire; pass it through instead of JSON-wrapping it.
-        if (isInputRequiredResult(result) || isCallToolResult(result)) {
-          return result;
+            try {
+              options.onToolCall?.({
+                name: toolName,
+                arguments: args,
+                annotations: tool.annotations,
+                ...res,
+              });
+            } catch (error) {
+              // Don't fail the tool call if the callback fails
+              console.error('Failed to run tool callback', error);
+            }
+
+            // Unwrap result
+            if (!res.success) {
+              throw res.error;
+            }
+            return res.data;
+          };
+
+          const result = await executeWithCallback(tool);
+
+          // An InputRequiredResult is already shaped for the wire.
+          if (isInputRequiredResult(result)) {
+            if (scope) {
+              outcome =
+                'isError' in result && result.isError === true
+                  ? 'tool_error'
+                  : 'input_required';
+            }
+            return result;
+          }
+
+          // A direct CallToolResult is already shaped for the wire; pass it
+          // through instead of JSON-wrapping it.
+          if (isCallToolResult(result)) {
+            if (scope) {
+              outcome =
+                result.isError === true
+                  ? 'tool_error'
+                  : (scope.consumedTerminal() ?? 'completed');
+            }
+            return result;
+          }
+
+          outcome = scope?.consumedTerminal() ?? 'completed';
+
+          const content =
+            result != null
+              ? [{ type: 'text' as const, text: JSON.stringify(result) }]
+              : [];
+
+          return {
+            content,
+          };
+        } catch (error) {
+          outcome = 'tool_error';
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ error: enumerateError(error) }),
+              },
+            ],
+          };
         }
-
-        const content =
-          result != null
-            ? [{ type: 'text' as const, text: JSON.stringify(result) }]
-            : [];
-
-        return {
-          content,
-        };
       } catch (error) {
-        return {
-          isError: true,
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({ error: enumerateError(error) }),
-            },
-          ],
-        };
+        outcome = 'handler_error';
+        throw error;
+      } finally {
+        scope?.end({
+          result: outcome,
+          durationMs: performance.now() - startedAt,
+        });
       }
     });
   }


### PR DESCRIPTION
## Why

Let hosts observe MCP requests without changing handler outcomes, exposing payloads, or doing observer work when observation is omitted.

## What changed

Adds an optional observer to `createMcpServer`, covering five handler lifecycles and six terminal outcomes. Custom tools can record finite cost facts through a safe third `Tool.execute` argument.

Observations contain bounded literals and durations, not raw arguments, results, state, or errors. Raw `onToolCall` is unchanged and not privacy-certified.

Observer calls are never awaited; throws and rejections are isolated. Without an observer, there is no scope, context, facts, clock, or Promise work; guards remain.

New tests are grouped by behavior; pre-existing tests are unchanged.

## How to test

Run `CI=true pnpm --filter @supabase/mcp-utils exec vitest run`. Expect 52 passing tests across 6 files, including SDK-boundary, error-outcome, and observer-failure checks covering lifecycles and noninterference.

## Trade-offs

Hosts own collection; synchronous observers can block. Handler duration excludes human wait and transport. Supabase integration and built-in cost producers are not included.

An extra, non-required `.cts` TypeScript check failed with TS1479 under unchanged package exports. Required checks passed; this does not establish a new regression. No export-map change is included.
