### PR TITLE
feat(mcp-server-supabase): add bounded cost lifecycle observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The PostgREST MCP server allows you to connect your own users to your app via RE
 
 See [CONTRIBUTING](./CONTRIBUTING.md) for details on how to contribute to this project.
 
-See [Observability](docs/observability.md) for the observer API.
+See [Observability](./docs/observability.md) for the optional observer API and versioned extension guidance.
 
 ## License
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,12 +1,12 @@
 # Observability
 
-The server provides an optional, vendor-neutral observer for five request-handler lifecycles and bounded facts recorded by tools, without exposing request contents. No collection, host metrics, provider, exporter, queue, or host adoption is configured by this API.
+The server provides an optional, vendor-neutral observer for five request-handler lifecycles and the existing cost-confirmation flow. It emits bounded facts without exposing request contents. No collection, host metrics, provider, exporter, queue, or host adoption is configured by this API.
 
 ## API and ownership
 
-Set `observer?: RequestObserver` on `McpServerOptions` for `createMcpServer`.
+Set `observer?: RequestObserver` on `McpServerOptions` for `createMcpServer` or on `SupabaseMcpServerOptions` for `createSupabaseMcpServer`. `createSupabaseMcpHandler` inherits the same options.
 
-`@supabase/mcp-utils` exports:
+Both `@supabase/mcp-utils` and `@supabase/mcp-server-supabase` export:
 
 - `ObservedMethod`
 - `ObservedTool`
@@ -22,7 +22,7 @@ Set `observer?: RequestObserver` on `McpServerOptions` for `createMcpServer`.
 - `record(fact): void | Promise<void>`
 - `end({ result, durationMs }): void | Promise<void>`
 
-Only the handler owns `end`. Tool code receives an optional safe, synchronous recorder through the additive third argument to `Tool.execute(params, context, record?: (fact: ObservationFact) => void)`. Existing one- and two-argument callers continue to work.
+Only the handler owns `end`. Tool code receives an optional safe, synchronous recorder through the additive third argument to `Tool.execute(params, context, record?: (fact: ObservationFact) => void)`. Existing one- and two-argument callers continue to work; `injectableTool` forwards the recorder.
 
 The observer factory must not return a Promise. An unsupported Promise return is discarded, with its rejection consumed.
 
@@ -58,9 +58,9 @@ Handler `durationMs` uses a monotonic clock from handler entry through response 
 
 Operation durations cover actual awaited protected calls, not the whole confirmation flow. `returned` does not prove readiness or commit; `threw` does not prove that nothing committed.
 
-## Tool-recorded facts: cost confirmation
+## Current facts: cost confirmation
 
-`ConfirmationFeature` contains only `cost`, and every fact has `feature: 'cost'`. Custom tools can record the full cost fact vocabulary; built-in Supabase cost instrumentation is not available.
+`ConfirmationFeature` currently contains only `cost`. Every current fact has `feature: 'cost'`.
 
 | `kind` | Fields and values |
 | --- | --- |
@@ -70,6 +70,22 @@ Operation durations cover actual awaited protected calls, not the whole confirma
 | `resume_validation` | `result: valid \| missing_response \| tool_mismatch \| arguments_mismatch \| changed_quote` |
 | `operation` | `disposition: started` |
 | `operation` | `disposition: returned \| threw`; `durationMs: number` |
+
+The decision pairs are:
+
+- `blocked/read_only`.
+- `legacy/not_configured`, checked before `legacy/capability_missing`.
+- `inline/eligible`.
+- Initial project-only `bypass/zero_cost`. Branch creation has no corresponding shortcut.
+
+Modern resume validation, missing responses, changed quotes, and actions use the literal facts above. Legacy hash checks are not reported as modern resume validation.
+
+All five actual protected project and branch call sites emit `operation/started`, followed by `operation/returned` or `operation/threw` with a duration. This includes legacy and zero-cost paths.
+
+`input_required` records successful issuance only after minting and response construction succeed. It does not establish delivery or display. `input_response/accept` records an action, not independently verified consent.
+
+Observation does not change confirmation rules or execution behavior.
+
 ## Failure isolation and disabled behavior
 
 With no observer, there is no scope, context, fact, clock, or Promise work. Guards and forwarding of `undefined` remain. If a configured factory returns `undefined`, the initial timestamp and context have already been created, but no subsequent facts, timing, or recorder are created for that scope.
@@ -86,3 +102,124 @@ The existing raw `onToolCall` callback is unchanged and is not certified privacy
 
 Hosts control any local collection, configuration, privacy policy, access, retention, and loss handling. None is enabled here. Hosts must not interpret missing observations as proof that an action did not occur.
 
+## Future extensions
+
+The following recipes are separately authorized contract and integration changes, not implemented features, dormant runtime branches, or blockers for the current observer. Each recipe is independently applicable. Either may land first; the second must retain the first's accepted members.
+
+### Release and adoption order
+
+Apply this sequence independently for each extension, including when the other extension has already shipped:
+
+1. Inspect and pin the actual accepted, merged feature implementation and its host integration. A proposal is not acceptance.
+2. Agree on the exact canonical declarations. Obtain producer and host type acknowledgment and deliberately choose a compatible package version. Finite-union additions can break exhaustive consumers, so they are not automatically minor changes.
+3. Publish an immutable package artifact and establish its integrity.
+4. Adopt that release in the host with lockfile integrity. Acknowledge the actual imported types, mappings, configuration, closed allowlists, schemas, and fixtures against the published contract.
+
+Do not substitute an unpublished source checkout, a proposed schema, or an assumed version for these steps.
+
+### Destructive SQL confirmation
+
+Before editing, inspect and pin the accepted, merged destructive-SQL implementation succeeding public MCP408 and its actual host integration. Preserve its parser, policy, and execution behavior.
+
+#### Contract delta
+
+- Add `'destructive_sql'` to `ConfirmationFeature`.
+- Add `not_destructive` to decision reasons.
+- Add `invalid_state` to resume-validation results only if the accepted implementation's combined `schema.safeParse` failure requires it. Otherwise, represent the actual branches deliberately rather than inventing a combined failure.
+- Widen **both** operation variants to `feature: 'cost' | 'destructive_sql'`: the `started` variant and the `returned | threw` variant with `durationMs`.
+- Reuse the existing `execute_sql` and `apply_migration` tool buckets. Add no tool bucket, issuance mode, action, or end result.
+- Retain every cost member, including `tool_mismatch` and `changed_quote`, even if a migrated checker no longer emits some of them.
+- If the URL extension has landed, retain its members. Do not add `'secret_collection'` to operations.
+
+#### Branches and ownership
+
+Emit these SQL decision pairs at the accepted branches:
+
+| Pair | Scope |
+| --- | --- |
+| `inline/eligible` | Eligible inline confirmation |
+| `bypass/not_configured` | Confirmation not configured |
+| `bypass/capability_missing` | Required capability missing |
+| `bypass/not_destructive` | Classifier reports not destructive |
+| `bypass/read_only` | `execute_sql` only |
+| `blocked/read_only` | `apply_migration` only |
+
+`not_destructive` reports the classifier's result, not global SQL safety. Generic observation counts do not prove parsing correctness or authorization.
+
+If the accepted implementation adopts shared `checkConfirmationState`, make that checker the sole owner of `input_response` and `resume_validation`. Remove duplicate inline account and branch records in the same change. Callers remain the sole owners of successful issuance and actual operation records.
+
+Preserve the distinctions between initial requests with no state and no validation, missing responses, argument mismatches, cost payload mismatches reported as `changed_quote`, and any actual combined `invalid_state` branch. Do not collapse these while migrating cost callers.
+
+Time the actual `executeSql` and `applyMigration` calls, including bypass paths. Do not time the parser or policy decision as an operation, and do not emit operations for decline, cancel, invalid, or missing-response paths.
+
+#### Producer and host changes
+
+Update canonical types, public exports, recorder consumers, and exhaustive fixtures. Update the host's actual imported types, closed allowlists, exhaustive switches, and sparse labels. Change the configuration snapshot only for the accepted implementation's actual per-tool option and skip branches. No new metric name is required.
+
+Complete the release and adoption sequence above and the successor proofs below. This recipe does not depend on URL confirmation.
+
+### URL secret collection
+
+Before editing, inspect and pin the accepted, merged secret-collection implementation succeeding public MCP412 and its actual host integration. Preserve its TTL, `issued_at`, recovery behavior, and gating.
+
+#### Contract delta
+
+- Add `secret_collection` to `ConfirmationFeature`.
+- Add `create_edge_function_secret` to `ObservedTool`.
+- Add decision reasons `recent_update` and `unsupported_client`.
+- Widen issuance modes to `form | url` and add issuance reason `update_not_observed`.
+- Add exactly this fact, with **no `feature` field**:
+
+    Readonly<{
+      kind: 'url_metadata';
+      observation:
+        | 'recent_update_observed'
+        | 'resume_update_observed'
+        | 'update_not_observed';
+    }>
+
+- Never add `secret_collection` to either operation variant. Operations retain `cost`, or `cost | destructive_sql` if SQL has landed.
+- Do not add `resume_validation.update_not_observed`. Do not add a URL-only `invalid_state` unless the accepted combined checker independently warrants that deliberate addition.
+- Retain existing cost members and any accepted SQL members. Do not create a SQL dependency for this recipe.
+
+#### Branches and ownership
+
+Preserve these exact branches:
+
+| Branch | Observations |
+| --- | --- |
+| Read-only block | `blocked/read_only` |
+| Initial unsupported client | `blocked/unsupported_client` |
+| Initial recent update | `bypass/recent_update` and `recent_update_observed` |
+| Normal initial issuance | `inline/eligible`, then successful `url/initial` issuance |
+| Retry | `inline/eligible`, without an invented capability check |
+
+Use the accepted implementation's actual mismatch, missing-response, and action branches. A validated accept emits `accept` and `valid` once, then either `resume_update_observed` or `update_not_observed`. The latter reissues `url/update_not_observed` while preserving `issued_at`.
+
+If a shared checker owns action and validation facts, remove duplicate caller records in the same change. Otherwise, leave cost instrumentation alone. Callers own successful issuance after minting and construction, not attempted issuance.
+
+Neither `getUpdatedAt` nor external dashboard writes are observed operations. There is no modern completion-notification hook. URL facts do not prove consent, display, opening, completion, a causal write, uniqueness, or abandonment.
+
+#### Producer and host changes
+
+Update canonical types, public exports, recorder consumers, and exhaustive fixtures. Update the host's actual imported types, mappings, closed allowlists, exhaustive switches, schemas, and sparse-label fixtures while preserving accepted gating and configuration.
+
+The future host integration adds `mcp_observer_url_metadata_total{observation}` with exactly three values: `recent_update_observed`, `resume_update_observed`, and `update_not_observed`. It has no tool, project, or URL labels. `create_edge_function_secret` becomes a named tool instead of `other`. Add no URL operation histogram. Update label fixtures and cardinality expectations.
+
+Complete the release and adoption sequence above and the successor proofs below. This metric and host integration are not configured by the current package.
+
+### Required successor proofs
+
+For each extension, establish these proofs against the accepted implementation and the published producer/host contract:
+
+- Every feature branch, plus every migrated cost branch, produces the intended facts without duplicate action or validation records.
+- Mint failure emits no issuance fact. Operations cover actual protected calls, including bypass paths, and never decline, cancel, invalid, or missing-response paths. URL collection emits no operation facts.
+- Business behavior remains unchanged. SDK pre-entry rejection remains outside observer scopes.
+- Privacy sentinels remain excluded; unknown or impossible DTOs are rejected at the intended contract boundaries.
+- Reverse-order concurrent completion, replay, and observation loss preserve attempt-local semantics without inventing correlation or delivery guarantees.
+- Host labels remain sparse and bounded. Cardinality fixtures and duration conversion to seconds agree with actual mappings. Verify the approved seconds buckets `[0.05,0.1,0.25,0.5,1,2,5,10,20,30,60]`, plus `+Inf`, count, and sum. These are future host-integration proofs, not metric registration by this package.
+- Public ESM and CJS consumption, exhaustive consumers, and old/new producer-host compatibility are exercised for the deliberately selected version. Adoption uses the immutable published artifact and matching lockfile integrity.
+
+For SQL, cover classifier, `readOnly`, configuration, capability, and skip branches, plus the accepted combined validation branches. Prove that generic counts are not presented as parsing or authorization evidence.
+
+For URL, cover supported and unsupported clients, hidden-but-callable behavior, mint failure, missing and non-elicitation responses, wrong-tool and argument mismatches, decline, cancel, TTL, `issued_at` preservation, gating, and the accepted fresh-call recovery behavior. Cover both metadata outcomes after validated accept and reissuance without inferring consent, display, opening, completion, causal writes, uniqueness, or abandonment.

--- a/packages/mcp-server-supabase/src/index.ts
+++ b/packages/mcp-server-supabase/src/index.ts
@@ -1,6 +1,16 @@
 import packageJson from '../package.json' with { type: 'json' };
 
-export type { ToolCallCallback } from '@supabase/mcp-utils';
+export type {
+  ObservationContext,
+  ObservationEnd,
+  ObservationFact,
+  ObservedMethod,
+  ObservedTool,
+  ConfirmationFeature,
+  RequestObservation,
+  RequestObserver,
+  ToolCallCallback,
+} from '@supabase/mcp-utils';
 export type { SupabasePlatform } from './platform/index.js';
 export {
   createSupabaseMcpServer,

--- a/packages/mcp-server-supabase/src/observation-confirmation.test.ts
+++ b/packages/mcp-server-supabase/src/observation-confirmation.test.ts
@@ -1,0 +1,312 @@
+import {
+  mintControl,
+  form,
+  tools,
+  setup,
+  issued,
+  decision,
+  required,
+  validation,
+  response,
+  started,
+  operationEnd,
+  assertAttempt,
+  changeQuote,
+} from './observation-test-helpers.js';
+import {
+  isInputRequiredResult,
+  type CallToolResult,
+} from '@modelcontextprotocol/client';
+import { describe, expect, test, vi } from 'vitest';
+import * as pricing from './pricing.js';
+import { hashObject } from './util.js';
+
+describe.each(tools)('%s observation', (name) => {
+  test('settles initial issuance immediately, without an operation or a waiting scope', async () => {
+    const h = await setup();
+    issued(await h.call(name));
+    assertAttempt(
+      h.attempts[0],
+      name,
+      [decision('inline', 'eligible'), required('initial')],
+      'input_required'
+    );
+    expect(h.operation(name)).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(h.attempts).toHaveLength(1);
+    expect(h.attempts[0]!.ends).toHaveLength(1);
+  });
+
+  test.each(['accept', 'decline', 'cancel'] as const)(
+    'records consumed %s and the actual operation only',
+    async (action) => {
+      const h = await setup({ injected: name === 'create_branch' });
+      const first = issued(await h.call(name));
+      const result = await h.call(name, {
+        requestState: first.requestState,
+        inputResponses: {
+          confirm_cost:
+            action === 'accept' ? { action, content: {} } : { action },
+        },
+      });
+      expect(isInputRequiredResult(result)).toBe(false);
+      const accepted = action === 'accept';
+      assertAttempt(
+        h.attempts[1],
+        name,
+        [
+          decision('inline', 'eligible'),
+          response(action),
+          ...(accepted
+            ? [validation('valid'), started, operationEnd('returned')]
+            : []),
+        ],
+        accepted ? 'completed' : action === 'decline' ? 'declined' : 'cancelled'
+      );
+      expect(h.operation(name)).toHaveBeenCalledTimes(accepted ? 1 : 0);
+      if (accepted) expect((result as CallToolResult).isError).not.toBe(true);
+    }
+  );
+
+  test.each([undefined, { confirm_cost: { roots: [] } }])(
+    'reissues missing/non-elicit response without a consumed action',
+    async (inputResponses) => {
+      const h = await setup();
+      const first = issued(await h.call(name));
+      issued(
+        await h.call(name, { requestState: first.requestState, inputResponses })
+      );
+      assertAttempt(
+        h.attempts[1],
+        name,
+        [
+          decision('inline', 'eligible'),
+          validation('missing_response'),
+          required('missing_response'),
+        ],
+        'input_required'
+      );
+      expect(h.operation(name)).not.toHaveBeenCalled();
+    }
+  );
+
+  test('accepting a changed quote issues another round rather than executing', async () => {
+    const h = await setup();
+    const first = issued(await h.call(name));
+    changeQuote(name);
+    issued(
+      await h.call(name, {
+        requestState: first.requestState,
+        inputResponses: { confirm_cost: { action: 'accept', content: {} } },
+      })
+    );
+    assertAttempt(
+      h.attempts[1],
+      name,
+      [
+        decision('inline', 'eligible'),
+        response('accept'),
+        validation('changed_quote'),
+        required('changed_quote'),
+      ],
+      'input_required'
+    );
+    expect(h.operation(name)).not.toHaveBeenCalled();
+  });
+
+  test.each(['initial', 'missing_response', 'changed_quote'] as const)(
+    'failed %s mint does not count an issued round',
+    async (reason) => {
+      const h = await setup();
+      const first =
+        reason === 'initial' ? undefined : issued(await h.call(name));
+      if (reason === 'changed_quote') changeQuote(name);
+      mintControl.fail = true;
+      const result = await h.call(
+        name,
+        first
+          ? {
+              requestState: first.requestState,
+              ...(reason === 'changed_quote'
+                ? {
+                    inputResponses: {
+                      confirm_cost: { action: 'accept' as const, content: {} },
+                    },
+                  }
+                : {}),
+            }
+          : {}
+      );
+      expect((result as CallToolResult).isError).toBe(true);
+      const prior =
+        reason === 'initial'
+          ? []
+          : reason === 'missing_response'
+            ? [validation('missing_response')]
+            : [response('accept'), validation('changed_quote')];
+      assertAttempt(
+        h.attempts.at(-1),
+        name,
+        [decision('inline', 'eligible'), ...prior],
+        'tool_error'
+      );
+      expect(h.operation(name)).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each(['tool_mismatch', 'arguments_mismatch'] as const)(
+    'rejects %s without consuming accept',
+    async (mismatch) => {
+      const h = await setup();
+      const other =
+        name === 'create_project' ? 'create_branch' : 'create_project';
+      const first = issued(
+        await h.call(mismatch === 'tool_mismatch' ? other : name)
+      );
+      const result = await h.call(name, {
+        requestState: first.requestState,
+        arguments: {
+          ...h.args(name),
+          ...(mismatch === 'arguments_mismatch'
+            ? { name: 'CHANGED_PRIVATE_NAME' }
+            : {}),
+        },
+        inputResponses: { confirm_cost: { action: 'accept', content: {} } },
+      });
+      expect((result as CallToolResult).isError).toBe(true);
+      assertAttempt(
+        h.attempts[1],
+        name,
+        [decision('inline', 'eligible'), validation(mismatch)],
+        'tool_error'
+      );
+      expect(h.operation(name)).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each([
+    {
+      legacy: true,
+      configured: false,
+      capabilities: {},
+      reason: 'not_configured' as const,
+    },
+    {
+      legacy: false,
+      configured: false,
+      capabilities: form,
+      reason: 'not_configured' as const,
+    },
+    {
+      legacy: true,
+      configured: true,
+      capabilities: form,
+      reason: 'capability_missing' as const,
+    },
+    {
+      legacy: false,
+      configured: true,
+      capabilities: {},
+      reason: 'capability_missing' as const,
+    },
+    {
+      legacy: false,
+      configured: true,
+      capabilities: { elicitation: { url: {} } },
+      reason: 'capability_missing' as const,
+    },
+  ])(
+    'preserves legacy protection: $legacy/$configured/$reason/$capabilities',
+    async (options) => {
+      const h = await setup(options);
+      const cost =
+        name === 'create_project'
+          ? { type: 'project', recurrence: 'monthly', amount: 10 }
+          : pricing.getBranchCost();
+      const result = await h.call(name, {
+        arguments: { ...h.args(name), confirm_cost_id: await hashObject(cost) },
+      });
+      expect((result as CallToolResult).isError).not.toBe(true);
+      assertAttempt(
+        h.attempts[0],
+        name,
+        [decision('legacy', options.reason), started, operationEnd('returned')],
+        'completed'
+      );
+      expect(h.operation(name)).toHaveBeenCalledTimes(1);
+      const failure = await h.call(name, {
+        arguments: { ...h.args(name), confirm_cost_id: 'PRIVATE_INVALID_HASH' },
+      });
+      expect((failure as CallToolResult).isError).toBe(true);
+      assertAttempt(
+        h.attempts[1],
+        name,
+        [decision('legacy', options.reason)],
+        'tool_error'
+      );
+      expect(h.operation(name)).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  test('read-only rejection is the decisive branch', async () => {
+    const h = await setup({ readOnly: true });
+    expect(((await h.call(name)) as CallToolResult).isError).toBe(true);
+    assertAttempt(
+      h.attempts[0],
+      name,
+      [decision('blocked', 'read_only')],
+      'tool_error'
+    );
+    expect(h.operation(name)).not.toHaveBeenCalled();
+  });
+
+  test.each(['signature', 'expiry'] as const)(
+    'SDK %s rejection creates no additional scope',
+    async (kind) => {
+      const h = await setup();
+      const first = issued(await h.call(name));
+      let requestState = first.requestState as string;
+      if (kind === 'signature') {
+        const segments = requestState.split('.');
+        const signature = segments.pop()!;
+        segments.push((signature[0] === 'a' ? 'b' : 'a') + signature.slice(1));
+        requestState = segments.join('.');
+      } else {
+        vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 120_000);
+      }
+      await expect(
+        h.call(name, {
+          requestState,
+          inputResponses: { confirm_cost: { action: 'accept', content: {} } },
+        })
+      ).rejects.toMatchObject({ code: -32602 });
+      expect(h.attempts).toHaveLength(1);
+      expect(h.operation(name)).not.toHaveBeenCalled();
+    }
+  );
+});
+
+test.each(tools)(
+  '%s decline/cancel takes precedence over a changed quote',
+  async (name) => {
+    const h = await setup();
+    const first = issued(await h.call(name));
+    changeQuote(name);
+    for (const action of ['decline', 'cancel'] as const) {
+      const result = await h.call(name, {
+        requestState: first.requestState,
+        inputResponses: { confirm_cost: { action } },
+      });
+      expect((result as CallToolResult).structuredContent).toEqual({
+        status: action === 'decline' ? 'declined' : 'cancelled',
+      });
+      assertAttempt(
+        h.attempts.at(-1),
+        name,
+        [decision('inline', 'eligible'), response(action)],
+        action === 'decline' ? 'declined' : 'cancelled'
+      );
+    }
+    expect(h.operation(name)).not.toHaveBeenCalled();
+  }
+);

--- a/packages/mcp-server-supabase/src/observation-isolation.test.ts
+++ b/packages/mcp-server-supabase/src/observation-isolation.test.ts
@@ -1,0 +1,143 @@
+import { setup, issued, form } from './observation-test-helpers.js';
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  PROTOCOL_VERSION_META_KEY,
+  type CallToolResult,
+} from '@modelcontextprotocol/client';
+import { describe, expect, test, vi } from 'vitest';
+import type { RequestObservation, RequestObserver } from './index.js';
+
+const failures = ['throw', 'reject', 'then_getter', 'never'] as const;
+function sinkFailure(kind: (typeof failures)[number]): unknown {
+  if (kind === 'throw') throw new Error('PRIVATE_SINK_ERROR');
+  if (kind === 'reject')
+    return Promise.reject(new Error('PRIVATE_SINK_REJECTION'));
+  if (kind === 'then_getter')
+    return Object.defineProperty({}, 'then', {
+      get() {
+        throw new Error('PRIVATE_THENABLE_ERROR');
+      },
+    });
+  return new Promise(() => {});
+}
+
+describe.each(['factory', 'record', 'end'] as const)(
+  '%s failure isolation through public server',
+  (target) => {
+    test.each(failures)(
+      '%s preserves platform return/error and onToolCall',
+      async (failure) => {
+        const onToolCall = vi.fn();
+        const observer = (() => {
+          if (target === 'factory') return sinkFailure(failure);
+          return {
+            record: () =>
+              target === 'record' ? sinkFailure(failure) : undefined,
+            end: () => (target === 'end' ? sinkFailure(failure) : undefined),
+          };
+        }) as RequestObserver;
+        const h = await setup({ observer, onToolCall });
+        h.platform.account.listProjects.mockResolvedValue([]);
+        const success = await h.call('create_project');
+        expect((success as CallToolResult).isError).not.toBe(true);
+        expect((success as CallToolResult).content).toEqual([
+          { type: 'text', text: JSON.stringify(h.project) },
+        ]);
+        h.createProject.mockRejectedValueOnce(
+          new Error('PRIVATE_BUSINESS_ERROR')
+        );
+        const failureResult = await h.call('create_project');
+        expect((failureResult as CallToolResult).isError).toBe(true);
+        expect(JSON.stringify(failureResult)).toContain(
+          'PRIVATE_BUSINESS_ERROR'
+        );
+        expect(h.createProject).toHaveBeenCalledTimes(2);
+        expect(onToolCall).toHaveBeenCalledTimes(2);
+        expect(onToolCall.mock.calls[0]![0]).toMatchObject({
+          name: 'create_project',
+          arguments: h.args('create_project'),
+          success: true,
+          data: h.project,
+        });
+        expect(onToolCall.mock.calls[1]![0]).toMatchObject({
+          name: 'create_project',
+          arguments: h.args('create_project'),
+          success: false,
+          error: expect.objectContaining({ message: 'PRIVATE_BUSINESS_ERROR' }),
+        });
+        await new Promise<void>((resolve) => queueMicrotask(resolve));
+      }
+    );
+  }
+);
+
+test.each(['record', 'end'] as const)(
+  'throwing %s property access cannot alter cost output',
+  async (target) => {
+    const observer: RequestObserver = () =>
+      Object.defineProperty({ record() {}, end() {} }, target, {
+        get() {
+          throw new Error('PRIVATE_GETTER');
+        },
+      }) as RequestObservation;
+    const h = await setup({ observer });
+    const first = issued(await h.call('create_branch'));
+    const result = await h.call('create_branch', {
+      requestState: first.requestState,
+      inputResponses: { confirm_cost: { action: 'cancel' } },
+    });
+    expect((result as CallToolResult).structuredContent).toEqual({
+      status: 'cancelled',
+    });
+    expect(h.createBranch).not.toHaveBeenCalled();
+  }
+);
+
+test('observer DTOs have closed keys and exclude arguments, state, URLs, results and errors', async () => {
+  const h = await setup();
+  const first = issued(
+    await h.call('create_project', {
+      arguments: {
+        ...h.args('create_project'),
+        name: 'PRIVATE_SQL SELECT secret',
+      },
+      _meta: {
+        private: 'PRIVATE_META',
+        [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
+        [CLIENT_CAPABILITIES_META_KEY]: form,
+      },
+    })
+  );
+  h.createProject.mockRejectedValueOnce(
+    new Error('PRIVATE_ERROR https://PRIVATE_ERROR_URL.test')
+  );
+  await h.call('create_project', {
+    requestState: first.requestState,
+    arguments: {
+      ...h.args('create_project'),
+      name: 'PRIVATE_SQL SELECT secret',
+    },
+    inputResponses: { confirm_cost: { action: 'accept', content: {} } },
+  });
+  expect(JSON.stringify(h.attempts)).not.toContain('PRIVATE_');
+  expect(JSON.stringify(h.attempts)).not.toContain(first.requestState);
+  const keys = {
+    confirmation_decision: ['feature', 'kind', 'reason', 'route'],
+    input_required: ['feature', 'kind', 'mode', 'reason'],
+    input_response: ['action', 'feature', 'kind'],
+    resume_validation: ['feature', 'kind', 'result'],
+    operation: ['disposition', 'feature', 'kind'],
+  };
+  for (const attempt of h.attempts) {
+    expect(Object.keys(attempt.context).sort()).toEqual(['method', 'tool']);
+    for (const fact of attempt.facts)
+      expect(Object.keys(fact).sort()).toEqual(
+        [
+          ...keys[fact.kind],
+          ...('durationMs' in fact ? ['durationMs'] : []),
+        ].sort()
+      );
+    for (const end of attempt.ends)
+      expect(Object.keys(end).sort()).toEqual(['durationMs', 'result']);
+  }
+});

--- a/packages/mcp-server-supabase/src/observation-operations.test.ts
+++ b/packages/mcp-server-supabase/src/observation-operations.test.ts
@@ -1,0 +1,223 @@
+import {
+  tools,
+  setup,
+  issued,
+  decision,
+  response,
+  validation,
+  started,
+  operationEnd,
+  assertAttempt,
+  required,
+} from './observation-test-helpers.js';
+import type { CallToolResult } from '@modelcontextprotocol/client';
+import { describe, expect, test, vi } from 'vitest';
+import type { Branch, Project } from './platform/types.js';
+import * as pricing from './pricing.js';
+import { hashObject } from './util.js';
+
+describe.each(tools)('%s observation', (name) => {
+  test('platform rejection wins over an accepted response', async () => {
+    const h = await setup();
+    const first = issued(await h.call(name));
+    h.operation(name).mockRejectedValueOnce(
+      new Error('PRIVATE_PLATFORM_ERROR')
+    );
+    const result = await h.call(name, {
+      requestState: first.requestState,
+      inputResponses: { confirm_cost: { action: 'accept', content: {} } },
+    });
+    expect((result as CallToolResult).isError).toBe(true);
+    assertAttempt(
+      h.attempts[1],
+      name,
+      [
+        decision('inline', 'eligible'),
+        response('accept'),
+        validation('valid'),
+        started,
+        operationEnd('threw'),
+      ],
+      'tool_error'
+    );
+    expect(h.operation(name)).toHaveBeenCalledTimes(1);
+  });
+
+  test('replaying accepted state counts independent attempts and repeated operations', async () => {
+    const h = await setup();
+    const first = issued(await h.call(name));
+    const resume = {
+      requestState: first.requestState,
+      inputResponses: {
+        confirm_cost: { action: 'accept' as const, content: {} },
+      },
+    };
+    await h.call(name, resume);
+    await h.call(name, resume);
+    expect(h.attempts).toHaveLength(3);
+    for (const attempt of h.attempts.slice(1))
+      assertAttempt(
+        attempt,
+        name,
+        [
+          decision('inline', 'eligible'),
+          response('accept'),
+          validation('valid'),
+          started,
+          operationEnd('returned'),
+        ],
+        'completed'
+      );
+    expect(h.operation(name)).toHaveBeenCalledTimes(2);
+  });
+});
+
+test('only an initial zero-cost project bypasses issuance; zero-cost branches still ask', async () => {
+  const h = await setup();
+  h.platform.account.listProjects.mockResolvedValue([]);
+  expect(((await h.call('create_project')) as CallToolResult).isError).not.toBe(
+    true
+  );
+  assertAttempt(
+    h.attempts[0],
+    'create_project',
+    [decision('bypass', 'zero_cost'), started, operationEnd('returned')],
+    'completed'
+  );
+  vi.spyOn(pricing, 'getBranchCost').mockReturnValue({
+    type: 'branch',
+    recurrence: 'hourly',
+    amount: 0,
+  });
+  issued(await h.call('create_branch'));
+  assertAttempt(
+    h.attempts[1],
+    'create_branch',
+    [decision('inline', 'eligible'), required('initial')],
+    'input_required'
+  );
+  expect(h.createProject).toHaveBeenCalledTimes(1);
+  expect(h.createBranch).not.toHaveBeenCalled();
+});
+
+test('a quote lookup failure settles the attempt without inventing eligibility', async () => {
+  const h = await setup();
+  h.platform.account.getOrganization.mockRejectedValueOnce(
+    new Error('PRIVATE_QUOTE_ERROR')
+  );
+  expect(((await h.call('create_project')) as CallToolResult).isError).toBe(
+    true
+  );
+  assertAttempt(h.attempts[0], 'create_project', [], 'tool_error');
+  expect(h.createProject).not.toHaveBeenCalled();
+});
+
+// Node 20 is supported; Promise.withResolvers is not available there.
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test('reverse completion keeps operation timings and terminal sequences request-local', async () => {
+  const h = await setup();
+  const projectFirst = issued(await h.call('create_project'));
+  const branchFirst = issued(await h.call('create_branch'));
+  let now = 10;
+  vi.spyOn(performance, 'now').mockImplementation(() => now);
+  const projectGate = deferred<Project>();
+  const branchGate = deferred<Branch>();
+  const projectEntered = deferred<void>();
+  const branchEntered = deferred<void>();
+  h.createProject.mockImplementationOnce(() => {
+    projectEntered.resolve();
+    return projectGate.promise;
+  });
+  h.createBranch.mockImplementationOnce(() => {
+    branchEntered.resolve();
+    return branchGate.promise;
+  });
+  const projectCall = h.call('create_project', {
+    requestState: projectFirst.requestState,
+    inputResponses: { confirm_cost: { action: 'accept', content: {} } },
+  });
+  await projectEntered.promise;
+  now = 20;
+  const branchCall = h.call('create_branch', {
+    requestState: branchFirst.requestState,
+    inputResponses: { confirm_cost: { action: 'accept', content: {} } },
+  });
+  await branchEntered.promise;
+  now = 30;
+  branchGate.resolve(h.branch);
+  await branchCall;
+  expect(h.attempts[2]!.ends).toEqual([]);
+  expect(h.attempts[3]!.ends).toEqual([
+    { result: 'completed', durationMs: 10 },
+  ]);
+  now = 50;
+  projectGate.resolve(h.project);
+  await projectCall;
+  expect(h.attempts[2]!.ends).toEqual([
+    { result: 'completed', durationMs: 40 },
+  ]);
+  expect(h.attempts[2]!.facts.at(-1)).toEqual({
+    kind: 'operation',
+    feature: 'cost',
+    disposition: 'returned',
+    durationMs: 40,
+  });
+  expect(h.attempts[3]!.facts.at(-1)).toEqual({
+    kind: 'operation',
+    feature: 'cost',
+    disposition: 'returned',
+    durationMs: 10,
+  });
+  expect(h.createProject).toHaveBeenCalledTimes(1);
+  expect(h.createBranch).toHaveBeenCalledTimes(1);
+});
+
+test.each(tools)(
+  '%s legacy platform rejection has operation facts, not a modern validation',
+  async (name) => {
+    const h = await setup({ legacy: true, capabilities: {} });
+    const cost =
+      name === 'create_project'
+        ? { type: 'project', recurrence: 'monthly', amount: 10 }
+        : pricing.getBranchCost();
+    h.operation(name).mockRejectedValueOnce(new Error('PRIVATE_LEGACY_ERROR'));
+    const result = await h.call(name, {
+      arguments: { ...h.args(name), confirm_cost_id: await hashObject(cost) },
+    });
+    expect((result as CallToolResult).isError).toBe(true);
+    assertAttempt(
+      h.attempts[0],
+      name,
+      [
+        decision('legacy', 'capability_missing'),
+        started,
+        operationEnd('threw'),
+      ],
+      'tool_error'
+    );
+    expect(h.operation(name)).toHaveBeenCalledTimes(1);
+  }
+);
+
+test('zero-cost project failure still reports the actual protected call', async () => {
+  const h = await setup();
+  h.platform.account.listProjects.mockResolvedValue([]);
+  h.createProject.mockRejectedValueOnce(new Error('PRIVATE_ZERO_COST_ERROR'));
+  expect(((await h.call('create_project')) as CallToolResult).isError).toBe(
+    true
+  );
+  assertAttempt(
+    h.attempts[0],
+    'create_project',
+    [decision('bypass', 'zero_cost'), started, operationEnd('threw')],
+    'tool_error'
+  );
+  expect(h.createProject).toHaveBeenCalledTimes(1);
+});

--- a/packages/mcp-server-supabase/src/observation-test-helpers.ts
+++ b/packages/mcp-server-supabase/src/observation-test-helpers.ts
@@ -1,0 +1,334 @@
+import {
+  Client,
+  isInputRequiredResult,
+  StreamableHTTPClientTransport,
+  type CallToolRequestParams,
+  type CallToolResult,
+  type ClientCapabilities,
+  type InputRequiredResult,
+  type InputResponses,
+} from '@modelcontextprotocol/client';
+import type * as ServerSdk from '@modelcontextprotocol/server';
+import { StreamTransport } from '@supabase/mcp-utils';
+import { afterEach, expect, vi } from 'vitest';
+import type {
+  ObservationContext,
+  ObservationEnd,
+  ObservationFact,
+  RequestObserver,
+} from './index.js';
+import type { Branch, Project, SupabasePlatform } from './platform/types.js';
+import * as pricing from './pricing.js';
+import {
+  createSupabaseMcpServer,
+  type SupabaseMcpServerOptions,
+} from './server.js';
+import { createSupabaseMcpHandler } from './transports/http.js';
+
+// Fail only issuance, retaining the real SDK codec and verification path.
+const mintControl = vi.hoisted(() => ({ fail: false }));
+vi.mock('@modelcontextprotocol/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof ServerSdk>();
+  return {
+    ...actual,
+    createRequestStateCodec: ((
+      ...args: Parameters<typeof actual.createRequestStateCodec>
+    ) => {
+      const codec = actual.createRequestStateCodec(...args);
+      return {
+        ...codec,
+        mint: (...mintArgs: Parameters<typeof codec.mint>) => {
+          if (mintControl.fail) throw new Error('PRIVATE_MINT_FAILURE');
+          return codec.mint(...mintArgs);
+        },
+      };
+    }) as typeof actual.createRequestStateCodec,
+  };
+});
+
+const confirmation = {
+  requestStateKey: 'a'.repeat(32),
+  principal: 'PRIVATE_PRINCIPAL',
+  ttlSeconds: 60,
+  enabledTools: ['create_project', 'create_branch'],
+} satisfies NonNullable<SupabaseMcpServerOptions['costConfirmation']>;
+const form: ClientCapabilities = { elicitation: { form: {} } };
+const tools = ['create_project', 'create_branch'] as const;
+type CostTool = (typeof tools)[number];
+type Attempt = {
+  context: ObservationContext;
+  facts: ObservationFact[];
+  ends: ObservationEnd[];
+};
+const cleanups: (() => Promise<void>)[] = [];
+
+afterEach(async () => {
+  mintControl.fail = false;
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  await Promise.all(cleanups.splice(0).map((close) => close()));
+});
+
+function fakePlatform() {
+  const project: Project = {
+    id: 'PRIVATE_PROJECT',
+    ref: 'PRIVATE_PROJECT',
+    organization_id: 'PRIVATE_ORG',
+    organization_slug: 'PRIVATE_SLUG',
+    name: 'PRIVATE_NAME',
+    status: 'ACTIVE_HEALTHY',
+    created_at: '2026-01-01',
+    region: 'us-east-1',
+  };
+  const branch: Branch = {
+    id: 'PRIVATE_BRANCH',
+    name: 'PRIVATE_NAME',
+    project_ref: 'PRIVATE_BRANCH_REF',
+    parent_project_ref: project.id,
+    is_default: false,
+    persistent: false,
+    status: 'CREATING_PROJECT',
+    created_at: '2026-01-01',
+    updated_at: '2026-01-01',
+  };
+  const createProject = vi.fn(async () => project);
+  const createBranch = vi.fn(async () => branch);
+  const platform = {
+    account: {
+      listOrganizations: vi.fn(async () => []),
+      getOrganization: vi.fn(async () => ({
+        id: 'PRIVATE_ORG',
+        name: 'PRIVATE_ORG_NAME',
+        plan: 'pro',
+        allowed_release_channels: [],
+        opt_in_tags: [],
+      })),
+      listProjects: vi.fn(async () => [project]),
+      getProject: vi.fn(async () => project),
+      createProject,
+      pauseProject: vi.fn(async () => {}),
+      restoreProject: vi.fn(async () => {}),
+    },
+    branching: {
+      createBranch,
+      listBranches: vi.fn(async () => []),
+      deleteBranch: vi.fn(async () => {}),
+      mergeBranch: vi.fn(async () => {}),
+      resetBranch: vi.fn(async () => {}),
+      rebaseBranch: vi.fn(async () => {}),
+    },
+  } satisfies SupabasePlatform;
+  return { platform, project, branch, createProject, createBranch };
+}
+
+async function setup(
+  options: {
+    legacy?: boolean;
+    capabilities?: ClientCapabilities;
+    configured?: boolean;
+    injected?: boolean;
+    readOnly?: boolean;
+    observer?: RequestObserver;
+    onToolCall?: SupabaseMcpServerOptions['onToolCall'];
+  } = {}
+) {
+  const fake = fakePlatform();
+  const attempts: Attempt[] = [];
+  const observer: RequestObserver =
+    options.observer ??
+    ((context) => {
+      const attempt: Attempt = { context, facts: [], ends: [] };
+      attempts.push(attempt);
+      return {
+        record: (fact) => {
+          attempt.facts.push(fact);
+        },
+        end: (end) => {
+          attempt.ends.push(end);
+        },
+      };
+    });
+  const serverOptions: SupabaseMcpServerOptions = {
+    platform: fake.platform,
+    features: ['account', 'branching'],
+    projectId: options.injected ? fake.project.id : undefined,
+    readOnly: options.readOnly,
+    costConfirmation: options.configured === false ? undefined : confirmation,
+    observer,
+    onToolCall: options.onToolCall,
+  };
+  const client = new Client(
+    { name: 'PRIVATE_CLIENT', version: '1.0' },
+    {
+      capabilities: options.capabilities ?? form,
+      ...(options.legacy
+        ? {}
+        : {
+            versionNegotiation: { mode: { pin: '2026-07-28' } },
+            inputRequired: { autoFulfill: false },
+          }),
+    }
+  );
+  if (options.legacy) {
+    const clientTransport = new StreamTransport();
+    const serverTransport = new StreamTransport();
+    const pipes = Promise.allSettled([
+      clientTransport.readable.pipeTo(serverTransport.writable),
+      serverTransport.readable.pipeTo(clientTransport.writable),
+    ]);
+    const server = createSupabaseMcpServer(serverOptions);
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    cleanups.push(async () => {
+      await client.close();
+      await server.close();
+      for (const result of await pipes) {
+        if (result.status === 'rejected') {
+          expect(result.reason).toMatchObject({ message: 'connection closed' });
+        }
+      }
+    });
+  } else {
+    const handler = createSupabaseMcpHandler(serverOptions);
+    await client.connect(
+      new StreamableHTTPClientTransport(
+        new URL('https://PRIVATE_URL.test/mcp'),
+        {
+          fetch: (url, init) => handler.fetch(new Request(url, init)),
+        }
+      )
+    );
+    cleanups.push(() => client.close());
+  }
+  attempts.length = 0;
+  function args(name: CostTool): Record<string, unknown> {
+    return name === 'create_project'
+      ? {
+          name: 'PRIVATE_NAME',
+          region: 'us-east-1',
+          organization_id: 'PRIVATE_ORG',
+        }
+      : {
+          name: 'PRIVATE_NAME',
+          ...(options.injected ? {} : { project_id: fake.project.id }),
+        };
+  }
+  async function call(
+    name: CostTool,
+    extra: Partial<CallToolRequestParams> &
+      Pick<InputRequiredResult, 'requestState'> & {
+        inputResponses?: InputResponses;
+      } = {}
+  ) {
+    return (await client.request(
+      {
+        method: 'tools/call',
+        params: { name, arguments: args(name), ...extra },
+      },
+      { allowInputRequired: true }
+    )) as CallToolResult | InputRequiredResult;
+  }
+  function operation(name: CostTool) {
+    return name === 'create_project' ? fake.createProject : fake.createBranch;
+  }
+  return { ...fake, client, attempts, args, call, operation };
+}
+
+function issued(
+  result: CallToolResult | InputRequiredResult
+): InputRequiredResult {
+  expect(isInputRequiredResult(result)).toBe(true);
+  if (!isInputRequiredResult(result))
+    throw new Error('expected input_required');
+  return result;
+}
+function decision(
+  route: 'inline' | 'legacy' | 'bypass' | 'blocked',
+  reason:
+    | 'eligible'
+    | 'not_configured'
+    | 'capability_missing'
+    | 'read_only'
+    | 'zero_cost'
+): ObservationFact {
+  return { kind: 'confirmation_decision', feature: 'cost', route, reason };
+}
+function required(
+  reason: 'initial' | 'missing_response' | 'changed_quote'
+): ObservationFact {
+  return { kind: 'input_required', feature: 'cost', mode: 'form', reason };
+}
+function validation(
+  result:
+    | 'valid'
+    | 'missing_response'
+    | 'tool_mismatch'
+    | 'arguments_mismatch'
+    | 'changed_quote'
+): ObservationFact {
+  return { kind: 'resume_validation', feature: 'cost', result };
+}
+function response(action: 'accept' | 'decline' | 'cancel'): ObservationFact {
+  return { kind: 'input_response', feature: 'cost', action };
+}
+const started: ObservationFact = {
+  kind: 'operation',
+  feature: 'cost',
+  disposition: 'started',
+};
+function operationEnd(disposition: 'returned' | 'threw') {
+  return {
+    kind: 'operation',
+    feature: 'cost',
+    disposition,
+    durationMs: expect.any(Number),
+  };
+}
+function assertAttempt(
+  attempt: Attempt | undefined,
+  name: CostTool,
+  facts: unknown[],
+  result: ObservationEnd['result']
+) {
+  expect(attempt).toEqual({
+    context: { method: 'tools/call', tool: name },
+    facts,
+    ends: [{ result, durationMs: expect.any(Number) }],
+  });
+  for (const event of [...attempt!.facts, ...attempt!.ends]) {
+    if ('durationMs' in event) {
+      expect(Number.isFinite(event.durationMs)).toBe(true);
+      expect(event.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  }
+}
+function changeQuote(name: CostTool) {
+  if (name === 'create_project')
+    vi.spyOn(pricing, 'getNextProjectCost').mockResolvedValue({
+      type: 'project',
+      recurrence: 'monthly',
+      amount: 20,
+    });
+  else
+    vi.spyOn(pricing, 'getBranchCost').mockReturnValue({
+      type: 'branch',
+      recurrence: 'hourly',
+      amount: 0.02,
+    });
+}
+
+export {
+  mintControl,
+  form,
+  tools,
+  setup,
+  issued,
+  decision,
+  required,
+  validation,
+  response,
+  started,
+  operationEnd,
+  assertAttempt,
+  changeQuote,
+};

--- a/packages/mcp-server-supabase/src/server.ts
+++ b/packages/mcp-server-supabase/src/server.ts
@@ -1,6 +1,7 @@
 import { createRequestStateCodec } from '@modelcontextprotocol/server';
 import {
   createMcpServer,
+  type RequestObserver,
   type Tool,
   type ToolCallCallback,
 } from '@supabase/mcp-utils';
@@ -60,6 +61,14 @@ export type SupabaseMcpServerOptions = {
    * Callback for after a supabase tool is called.
    */
   onToolCall?: ToolCallCallback;
+
+  /**
+   * Optional observer invoked once per general MCP handler entry
+   * (`tools/call`, `tools/list`, `resources/list`,
+   * `resources/templates/list`, `resources/read`) and forwarded unchanged
+   * to the underlying `@supabase/mcp-utils` server.
+   */
+  observer?: RequestObserver;
 
   /**
    * Enables cost confirmation via elicitation for clients that declare
@@ -122,6 +131,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
     contentApiUrl = 'https://supabase.com/docs/api/graphql',
     onToolCall,
     costConfirmation,
+    observer,
   } = options;
 
   const contentApiClientPromise = createContentApiClient(contentApiUrl, {
@@ -168,6 +178,7 @@ export function createSupabaseMcpServer(options: SupabaseMcpServerOptions) {
       ]);
     },
     onToolCall,
+    observer,
     requestState: costConfirmationCodec && {
       verify: costConfirmationCodec.verify,
     },

--- a/packages/mcp-server-supabase/src/tools/account-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/account-tools.ts
@@ -4,7 +4,7 @@ import {
   type RequestStateCodec,
   type ServerContext,
 } from '@modelcontextprotocol/server';
-import { tool } from '@supabase/mcp-utils';
+import { type ObservationFact, tool } from '@supabase/mcp-utils';
 import { z } from 'zod/v4';
 import type { ToolDefs } from './util.js';
 import {
@@ -307,9 +307,16 @@ export function getAccountTools({
           organization_id,
           confirm_cost_id,
         }: z.infer<typeof createProjectInputSchemaWithElicitation>,
-        ctx: ServerContext
+        ctx: ServerContext,
+        record?: (fact: ObservationFact) => void
       ) => {
         if (readOnly) {
+          record?.({
+            kind: 'confirmation_decision',
+            feature: 'cost',
+            route: 'blocked',
+            reason: 'read_only',
+          });
           throw new Error('Cannot create a project in read-only mode.');
         }
 
@@ -318,17 +325,55 @@ export function getAccountTools({
           const cost = await getNextProjectCost(account, organization_id);
           const state = ctx.mcpReq.requestState<CostConfirmationState>();
           if (!state && cost.amount === 0) {
-            return await account.createProject({
-              name,
-              region,
-              organization_id,
+            record?.({
+              kind: 'confirmation_decision',
+              feature: 'cost',
+              route: 'bypass',
+              reason: 'zero_cost',
             });
+            const startedAt = record ? performance.now() : 0;
+            record?.({
+              kind: 'operation',
+              feature: 'cost',
+              disposition: 'started',
+            });
+            try {
+              const result = await account.createProject({
+                name,
+                region,
+                organization_id,
+              });
+              record?.({
+                kind: 'operation',
+                feature: 'cost',
+                disposition: 'returned',
+                durationMs: performance.now() - startedAt,
+              });
+              return result;
+            } catch (error) {
+              record?.({
+                kind: 'operation',
+                feature: 'cost',
+                disposition: 'threw',
+                durationMs: performance.now() - startedAt,
+              });
+              throw error;
+            }
           }
+
+          record?.({
+            kind: 'confirmation_decision',
+            feature: 'cost',
+            route: 'inline',
+            reason: 'eligible',
+          });
 
           const costSuffix = cost.recurrence === 'monthly' ? '/month' : '/hr';
 
-          const askForConfirmation = async () =>
-            inputRequired({
+          const askForConfirmation = async (
+            reason: 'initial' | 'missing_response' | 'changed_quote'
+          ) => {
+            const result = inputRequired({
               inputRequests: {
                 confirm_cost: inputRequired.elicit({
                   mode: 'form',
@@ -345,12 +390,25 @@ export function getAccountTools({
                 ctx
               ),
             });
+            record?.({
+              kind: 'input_required',
+              feature: 'cost',
+              mode: 'form',
+              reason,
+            });
+            return result;
+          };
 
           if (!state) {
-            return askForConfirmation();
+            return askForConfirmation('initial');
           }
 
           if (state.tool !== 'create_project') {
+            record?.({
+              kind: 'resume_validation',
+              feature: 'cost',
+              result: 'tool_mismatch',
+            });
             return {
               content: [
                 {
@@ -368,6 +426,11 @@ export function getAccountTools({
             state.region !== region ||
             state.organization_id !== organization_id
           ) {
+            record?.({
+              kind: 'resume_validation',
+              feature: 'cost',
+              result: 'arguments_mismatch',
+            });
             return {
               content: [
                 {
@@ -385,10 +448,20 @@ export function getAccountTools({
             'confirm_cost'
           );
           if (response.kind !== 'elicit') {
-            return askForConfirmation();
+            record?.({
+              kind: 'resume_validation',
+              feature: 'cost',
+              result: 'missing_response',
+            });
+            return askForConfirmation('missing_response');
           }
 
           if (response.action === 'decline') {
+            record?.({
+              kind: 'input_response',
+              feature: 'cost',
+              action: 'decline',
+            });
             return {
               content: [
                 {
@@ -401,6 +474,11 @@ export function getAccountTools({
           }
 
           if (response.action !== 'accept') {
+            record?.({
+              kind: 'input_response',
+              feature: 'cost',
+              action: 'cancel',
+            });
             return {
               content: [
                 {
@@ -412,6 +490,12 @@ export function getAccountTools({
             };
           }
 
+          record?.({
+            kind: 'input_response',
+            feature: 'cost',
+            action: 'accept',
+          });
+
           if (
             cost.amount !== 0 &&
             (state.cost.type !== cost.type ||
@@ -422,17 +506,56 @@ export function getAccountTools({
             // plan or active-project count shifted) - reissue a fresh
             // prompt bound to the recomputed cost rather than honoring a
             // stale quote.
-            return askForConfirmation();
+            record?.({
+              kind: 'resume_validation',
+              feature: 'cost',
+              result: 'changed_quote',
+            });
+            return askForConfirmation('changed_quote');
           }
 
-          return await account.createProject({
-            name: state.name,
-            region: state.region,
-            organization_id: state.organization_id,
+          record?.({
+            kind: 'resume_validation',
+            feature: 'cost',
+            result: 'valid',
           });
+          const startedAt = record ? performance.now() : 0;
+          record?.({
+            kind: 'operation',
+            feature: 'cost',
+            disposition: 'started',
+          });
+          try {
+            const result = await account.createProject({
+              name: state.name,
+              region: state.region,
+              organization_id: state.organization_id,
+            });
+            record?.({
+              kind: 'operation',
+              feature: 'cost',
+              disposition: 'returned',
+              durationMs: performance.now() - startedAt,
+            });
+            return result;
+          } catch (error) {
+            record?.({
+              kind: 'operation',
+              feature: 'cost',
+              disposition: 'threw',
+              durationMs: performance.now() - startedAt,
+            });
+            throw error;
+          }
         }
 
         const cost = await getNextProjectCost(account, organization_id);
+        record?.({
+          kind: 'confirmation_decision',
+          feature: 'cost',
+          route: 'legacy',
+          reason: costConfirmation ? 'capability_missing' : 'not_configured',
+        });
         const costHash = await hashObject(cost);
         if (costHash !== confirm_cost_id) {
           throw new Error(
@@ -440,11 +563,34 @@ export function getAccountTools({
           );
         }
 
-        return await account.createProject({
-          name,
-          region,
-          organization_id,
+        const startedAt = record ? performance.now() : 0;
+        record?.({
+          kind: 'operation',
+          feature: 'cost',
+          disposition: 'started',
         });
+        try {
+          const result = await account.createProject({
+            name,
+            region,
+            organization_id,
+          });
+          record?.({
+            kind: 'operation',
+            feature: 'cost',
+            disposition: 'returned',
+            durationMs: performance.now() - startedAt,
+          });
+          return result;
+        } catch (error) {
+          record?.({
+            kind: 'operation',
+            feature: 'cost',
+            disposition: 'threw',
+            durationMs: performance.now() - startedAt,
+          });
+          throw error;
+        }
       },
     }),
     pause_project: tool({

--- a/packages/mcp-server-supabase/src/tools/branching-tools.ts
+++ b/packages/mcp-server-supabase/src/tools/branching-tools.ts
@@ -4,7 +4,7 @@ import {
   type RequestStateCodec,
   type ServerContext,
 } from '@modelcontextprotocol/server';
-import { tool } from '@supabase/mcp-utils';
+import { type ObservationFact, tool } from '@supabase/mcp-utils';
 import { z } from 'zod/v4';
 import type { BranchingOperations } from '../platform/types.js';
 import { branchSchema } from '../platform/types.js';
@@ -201,19 +201,34 @@ export function getBranchingTools({
           name,
           confirm_cost_id,
         }: z.infer<typeof createBranchInputSchemaWithElicitation>,
-        ctx: ServerContext
+        ctx: ServerContext,
+        record?: (fact: ObservationFact) => void
       ) => {
         if (readOnly) {
+          record?.({
+            kind: 'confirmation_decision',
+            feature: 'cost',
+            route: 'blocked',
+            reason: 'read_only',
+          });
           throw new Error('Cannot create a branch in read-only mode.');
         }
 
         if (costConfirmation && isFormCapable(ctx)) {
           const { codec } = costConfirmation;
           const cost = getBranchCost();
+          record?.({
+            kind: 'confirmation_decision',
+            feature: 'cost',
+            route: 'inline',
+            reason: 'eligible',
+          });
           const costSuffix = { hourly: '/hr' }[cost.recurrence];
 
-          const askForConfirmation = async () =>
-            inputRequired({
+          const askForConfirmation = async (
+            reason: 'initial' | 'missing_response' | 'changed_quote'
+          ) => {
+            const result = inputRequired({
               inputRequests: {
                 confirm_cost: inputRequired.elicit({
                   mode: 'form',
@@ -230,13 +245,26 @@ export function getBranchingTools({
                 ctx
               ),
             });
+            record?.({
+              kind: 'input_required',
+              feature: 'cost',
+              mode: 'form',
+              reason,
+            });
+            return result;
+          };
 
           const state = ctx.mcpReq.requestState<CostConfirmationState>();
           if (!state) {
-            return askForConfirmation();
+            return askForConfirmation('initial');
           }
 
           if (state.tool !== 'create_branch') {
+            record?.({
+              kind: 'resume_validation',
+              feature: 'cost',
+              result: 'tool_mismatch',
+            });
             return {
               content: [
                 {
@@ -250,6 +278,11 @@ export function getBranchingTools({
           }
 
           if (state.project_id !== project_id || state.name !== name) {
+            record?.({
+              kind: 'resume_validation',
+              feature: 'cost',
+              result: 'arguments_mismatch',
+            });
             return {
               content: [
                 {
@@ -267,10 +300,20 @@ export function getBranchingTools({
             'confirm_cost'
           );
           if (response.kind !== 'elicit') {
-            return askForConfirmation();
+            record?.({
+              kind: 'resume_validation',
+              feature: 'cost',
+              result: 'missing_response',
+            });
+            return askForConfirmation('missing_response');
           }
 
           if (response.action === 'decline') {
+            record?.({
+              kind: 'input_response',
+              feature: 'cost',
+              action: 'decline',
+            });
             return {
               content: [
                 {
@@ -283,6 +326,11 @@ export function getBranchingTools({
           }
 
           if (response.action !== 'accept') {
+            record?.({
+              kind: 'input_response',
+              feature: 'cost',
+              action: 'cancel',
+            });
             return {
               content: [
                 {
@@ -294,6 +342,12 @@ export function getBranchingTools({
             };
           }
 
+          record?.({
+            kind: 'input_response',
+            feature: 'cost',
+            action: 'accept',
+          });
+
           if (
             state.cost.type !== cost.type ||
             state.cost.recurrence !== cost.recurrence ||
@@ -302,22 +356,84 @@ export function getBranchingTools({
             // Pricing changed since the state was minted - reissue a
             // fresh prompt bound to the recomputed cost rather than
             // honoring a stale quote.
-            return askForConfirmation();
+            record?.({
+              kind: 'resume_validation',
+              feature: 'cost',
+              result: 'changed_quote',
+            });
+            return askForConfirmation('changed_quote');
           }
 
-          return await branching.createBranch(state.project_id, {
-            name: state.name,
+          record?.({
+            kind: 'resume_validation',
+            feature: 'cost',
+            result: 'valid',
           });
+          const startedAt = record ? performance.now() : 0;
+          record?.({
+            kind: 'operation',
+            feature: 'cost',
+            disposition: 'started',
+          });
+          try {
+            const result = await branching.createBranch(state.project_id, {
+              name: state.name,
+            });
+            record?.({
+              kind: 'operation',
+              feature: 'cost',
+              disposition: 'returned',
+              durationMs: performance.now() - startedAt,
+            });
+            return result;
+          } catch (error) {
+            record?.({
+              kind: 'operation',
+              feature: 'cost',
+              disposition: 'threw',
+              durationMs: performance.now() - startedAt,
+            });
+            throw error;
+          }
         }
 
         const cost = getBranchCost();
+        record?.({
+          kind: 'confirmation_decision',
+          feature: 'cost',
+          route: 'legacy',
+          reason: costConfirmation ? 'capability_missing' : 'not_configured',
+        });
         const costHash = await hashObject(cost);
         if (costHash !== confirm_cost_id) {
           throw new Error(
             'Cost confirmation ID does not match the expected cost of creating a branch.'
           );
         }
-        return await branching.createBranch(project_id, { name });
+        const startedAt = record ? performance.now() : 0;
+        record?.({
+          kind: 'operation',
+          feature: 'cost',
+          disposition: 'started',
+        });
+        try {
+          const result = await branching.createBranch(project_id, { name });
+          record?.({
+            kind: 'operation',
+            feature: 'cost',
+            disposition: 'returned',
+            durationMs: performance.now() - startedAt,
+          });
+          return result;
+        } catch (error) {
+          record?.({
+            kind: 'operation',
+            feature: 'cost',
+            disposition: 'threw',
+            durationMs: performance.now() - startedAt,
+          });
+          throw error;
+        }
       },
     }),
     list_branches: injectableTool({

--- a/packages/mcp-server-supabase/src/tools/util.ts
+++ b/packages/mcp-server-supabase/src/tools/util.ts
@@ -1,5 +1,10 @@
 import { type ServerContext } from '@modelcontextprotocol/server';
-import { type Annotations, type Tool, tool } from '@supabase/mcp-utils';
+import {
+  type Annotations,
+  type ObservationFact,
+  type Tool,
+  tool,
+} from '@supabase/mcp-utils';
 import { source } from 'common-tags';
 import { z } from 'zod/v4';
 
@@ -73,9 +78,10 @@ export function injectableTool<
   // Wrapper that merges injected values with provided args
   const executeWithInjection = async (
     args: z.infer<typeof cleanParametersSchema>,
-    ctx: ServerContext
+    ctx: ServerContext,
+    record?: (fact: ObservationFact) => void
   ) => {
-    return execute({ ...args, ...inject } as z.infer<Params>, ctx);
+    return execute({ ...args, ...inject } as z.infer<Params>, ctx, record);
   };
 
   return tool({

--- a/scripts/fixtures/packed-platform-consumer/cjs-check.cjs
+++ b/scripts/fixtures/packed-platform-consumer/cjs-check.cjs
@@ -6,4 +6,11 @@ if (typeof createSupabaseMcpHandler !== 'function') {
   );
 }
 
-console.log('CJS_OK');
+// Exercise the require()-loaded implementation, not merely its export shape.
+import('./modern-call.mjs')
+  .then(({ runConsumer }) => runConsumer(createSupabaseMcpHandler))
+  .then(() => console.log('CJS_OK'))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/scripts/fixtures/packed-platform-consumer/modern-call.mjs
+++ b/scripts/fixtures/packed-platform-consumer/modern-call.mjs
@@ -1,3 +1,5 @@
+import assert from 'node:assert/strict';
+import { pathToFileURL } from 'node:url';
 import {
   Client,
   StreamableHTTPClientTransport,
@@ -7,78 +9,225 @@ import { createSupabaseMcpHandler } from '@supabase/mcp-server-supabase';
 // https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
 const MODERN_PROTOCOL_VERSION = '2026-07-28';
 
-// Stubbed `account` operations only run on a tool call. The account feature
-// registers real zod-built schemas, and the tools/list checks below verify
-// that create_project keeps its required properties with Platform's zod pin.
-// `docs` stays out: its tool description lazily calls supabase.com, and this
-// exchange must never leave the process.
-const notImplemented = () => Promise.reject(new Error('not implemented'));
+const project = {
+  id: 'PRIVATE_PROJECT_ID',
+  ref: 'PRIVATE_PROJECT_REF',
+  organization_id: 'PRIVATE_ORGANIZATION',
+  organization_slug: 'PRIVATE_SLUG',
+  name: 'PRIVATE_PROJECT_NAME',
+  status: 'ACTIVE_HEALTHY',
+  created_at: '2026-01-01T00:00:00Z',
+  region: 'us-east-1',
+};
+const args = {
+  name: project.name,
+  region: project.region,
+  organization_id: project.organization_id,
+};
+const decision = {
+  kind: 'confirmation_decision',
+  feature: 'cost',
+  route: 'inline',
+  reason: 'eligible',
+};
+const issuance = {
+  kind: 'input_required',
+  feature: 'cost',
+  mode: 'form',
+  reason: 'initial',
+};
 
-const handler = createSupabaseMcpHandler({
-  platform: {
-    account: {
-      listOrganizations: notImplemented,
-      getOrganization: notImplemented,
-      listProjects: notImplemented,
-      getProject: notImplemented,
-      createProject: notImplemented,
-      pauseProject: notImplemented,
-      restoreProject: notImplemented,
+function assertDuration(durationMs) {
+  assert.equal(typeof durationMs, 'number');
+  assert.ok(Number.isFinite(durationMs) && durationMs >= 0);
+}
+
+// CJS calls this same scenario with its require()-loaded constructor. The SDK
+// transport stays fetch-in-process: no listener, credentials or backend.
+export async function runConsumer(createHandler = createSupabaseMcpHandler) {
+  const scopes = [];
+  let sinkFailure;
+  let creates = 0;
+  const observer = (context) => {
+    if (sinkFailure === 'factory') throw new Error('PRIVATE_FACTORY_ERROR');
+    const scope = { context, facts: [], ends: [] };
+    scopes.push(scope);
+    return {
+      record(fact) {
+        scope.facts.push(fact);
+        if (sinkFailure === 'sink') throw new Error('PRIVATE_RECORD_ERROR');
+      },
+      end(end) {
+        scope.ends.push(end);
+        if (sinkFailure === 'sink') throw new Error('PRIVATE_END_ERROR');
+      },
+    };
+  };
+  const notImplemented = () =>
+    Promise.reject(new Error('unexpected platform call'));
+  const handler = createHandler({
+    observer,
+    platform: {
+      account: {
+        listOrganizations: notImplemented,
+        getOrganization: async () => ({
+          id: project.organization_id,
+          name: 'PRIVATE_ORG_NAME',
+          plan: 'pro',
+          allowed_release_channels: [],
+          opt_in_tags: [],
+        }),
+        listProjects: async () => [project],
+        getProject: notImplemented,
+        createProject: async (input) => {
+          assert.deepEqual(input, args);
+          creates++;
+          return project;
+        },
+        pauseProject: notImplemented,
+        restoreProject: notImplemented,
+      },
     },
-  },
-  features: ['account'],
-});
+    // docs descriptions can fetch supabase.com; deliberately register account only.
+    features: ['account'],
+    costConfirmation: {
+      requestStateKey: 'a'.repeat(32), // fixed test-only key, never a credential
+      principal: 'PRIVATE_PRINCIPAL',
+      enabledTools: ['create_project'],
+    },
+  });
+  const transport = new StreamableHTTPClientTransport(
+    new URL('http://packed-platform-consumer-fixture.invalid/mcp'),
+    { fetch: (url, init) => handler.fetch(new Request(url, init)) }
+  );
+  const client = new Client(
+    { name: 'PRIVATE_CLIENT_NAME', version: '0.0.0' },
+    {
+      capabilities: { elicitation: { form: {} } },
+      versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } },
+      inputRequired: { autoFulfill: false },
+    }
+  );
+  const call = (params) =>
+    client.request(
+      { method: 'tools/call', params },
+      { allowInputRequired: true }
+    );
+  const start = () => call({ name: 'create_project', arguments: args });
+  const resume = (first, action) =>
+    call({
+      name: 'create_project',
+      arguments: args,
+      requestState: first.requestState,
+      inputResponses: {
+        confirm_cost:
+          action === 'accept' ? { action, content: {} } : { action },
+      },
+    });
+  try {
+    await client.connect(transport);
+    assert.equal(
+      scopes.length,
+      0,
+      'initialize must not start a producer scope'
+    );
+    const { tools } = await client.listTools();
+    const listProjects = tools.find((tool) => tool.name === 'list_projects');
+    assert.ok(listProjects?.inputSchema);
+    const createProject = tools.find((tool) => tool.name === 'create_project');
+    assert.ok(createProject?.inputSchema?.properties);
+    for (const property of ['name', 'region', 'organization_id']) {
+      assert.ok(
+        Object.hasOwn(createProject.inputSchema.properties, property),
+        `missing schema property ${property}`
+      );
+    }
+    assert.deepEqual(scopes[0].context, {
+      method: 'tools/list',
+      tool: 'not_applicable',
+    });
+    assert.deepEqual(scopes[0].facts, []);
+    assert.equal(scopes[0].ends[0].result, 'completed');
 
-const transport = new StreamableHTTPClientTransport(
-  new URL('http://packed-platform-consumer-fixture.invalid/mcp'),
-  {
-    // Routes every request straight into the handler's fetch face in-process.
-    fetch: (url, init) => handler.fetch(new Request(url, init)),
+    const first = await start();
+    assert.ok(first.inputRequests?.confirm_cost);
+    assert.equal(typeof first.requestState, 'string');
+    assert.equal(creates, 0);
+    assert.deepEqual(scopes[1].facts, [decision, issuance]);
+    assert.equal(scopes[1].ends[0].result, 'input_required');
+    const accepted = await resume(first, 'accept');
+    assert.equal(accepted.isError, undefined);
+    assert.deepEqual(accepted.content, [
+      { type: 'text', text: JSON.stringify(project) },
+    ]);
+    assert.equal(creates, 1);
+    const acceptedScope = scopes[2];
+    assert.deepEqual(acceptedScope.facts.slice(0, 4), [
+      decision,
+      { kind: 'input_response', feature: 'cost', action: 'accept' },
+      { kind: 'resume_validation', feature: 'cost', result: 'valid' },
+      { kind: 'operation', feature: 'cost', disposition: 'started' },
+    ]);
+    const operation = acceptedScope.facts[4];
+    assertDuration(operation.durationMs);
+    assert.deepEqual(operation, {
+      kind: 'operation',
+      feature: 'cost',
+      disposition: 'returned',
+      durationMs: operation.durationMs,
+    });
+    assert.equal(acceptedScope.facts.length, 5);
+    assert.equal(acceptedScope.ends[0].result, 'completed');
+    assert.ok(acceptedScope.ends[0].durationMs >= operation.durationMs);
+
+    const declined = await resume(await start(), 'decline');
+    assert.deepEqual(declined.structuredContent, { status: 'declined' });
+    assert.equal(creates, 1);
+    assert.deepEqual(scopes[4].facts, [
+      decision,
+      { kind: 'input_response', feature: 'cost', action: 'decline' },
+    ]);
+    assert.equal(scopes[4].ends[0].result, 'declined');
+
+    // Sink and factory failures cannot suppress issuance or the paid operation.
+    for (const failure of ['sink', 'factory']) {
+      sinkFailure = failure;
+      const result = await resume(await start(), 'accept');
+      assert.deepEqual(result, accepted);
+    }
+    sinkFailure = undefined;
+    assert.equal(creates, 3);
+    for (const scope of scopes) {
+      assert.deepEqual(
+        scope.context,
+        scope === scopes[0]
+          ? { method: 'tools/list', tool: 'not_applicable' }
+          : { method: 'tools/call', tool: 'create_project' }
+      );
+      assert.equal(scope.ends.length, 1);
+      const end = scope.ends[0];
+      assertDuration(end.durationMs);
+      assert.deepEqual(Object.keys(end).sort(), ['durationMs', 'result']);
+    }
+    const serialized = JSON.stringify(scopes);
+    assert.ok(
+      !serialized.includes('PRIVATE_'),
+      'payload or sink error leaked into observations'
+    );
+    assert.ok(
+      !serialized.includes(first.requestState),
+      'signed state leaked into observations'
+    );
+    return tools.length;
+  } finally {
+    await client.close();
+    await handler.close();
   }
-);
-
-const client = new Client(
-  { name: 'packed-platform-consumer-fixture', version: '0.0.0' },
-  { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } }
-);
-
-await client.connect(transport);
-const { tools } = await client.listTools();
-
-// The no-argument witness proves that list_projects and its input schema are
-// present. The parameterized create_project witness below proves that the
-// zod-built schema keeps its required inputs across the dependency boundary.
-const listProjects = tools.find((tool) => tool.name === 'list_projects');
-
-if (!listProjects?.inputSchema) {
-  throw new Error(
-    `tools/list did not return list_projects with an input schema (got: ${JSON.stringify(tools.map((tool) => tool.name))})`
-  );
 }
 
-const createProject = tools.find((tool) => tool.name === 'create_project');
-
-if (!createProject?.inputSchema?.properties) {
-  throw new Error(
-    `tools/list did not return create_project with input schema properties (got: ${JSON.stringify(tools.map((tool) => tool.name))})`
-  );
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  console.log(`MODERN_CALL_OK tools=${await runConsumer()}`);
 }
-
-const requiredCreateProjectProperties = ['name', 'region', 'organization_id'];
-const createProjectProperties = Object.keys(
-  createProject.inputSchema.properties
-);
-const missingCreateProjectProperties = requiredCreateProjectProperties.filter(
-  (property) => !createProjectProperties.includes(property)
-);
-
-if (missingCreateProjectProperties.length > 0) {
-  throw new Error(
-    `create_project input schema is missing required properties: ${missingCreateProjectProperties.join(', ')} (got: ${JSON.stringify(createProjectProperties)})`
-  );
-}
-
-await client.close();
-await handler.close();
-
-console.log(`MODERN_CALL_OK tools=${tools.length}`);

--- a/scripts/fixtures/packed-platform-consumer/types-check.ts
+++ b/scripts/fixtures/packed-platform-consumer/types-check.ts
@@ -1,8 +1,176 @@
 import {
   createSupabaseMcpHandler,
+  createSupabaseMcpServer,
   type SupabaseMcpServerOptions,
 } from '@supabase/mcp-server-supabase';
 
+import {
+  createMcpServer,
+  tool,
+  type McpServerOptions,
+  type Tool,
+} from '@supabase/mcp-utils';
+import type * as Utils from '@supabase/mcp-utils';
+import type * as Supabase from '@supabase/mcp-server-supabase';
+import { z } from 'zod/v4';
+
+type ExpectedMethod =
+  | 'tools/call'
+  | 'tools/list'
+  | 'resources/list'
+  | 'resources/templates/list'
+  | 'resources/read';
+type ExpectedTool =
+  | 'create_project'
+  | 'create_branch'
+  | 'execute_sql'
+  | 'apply_migration'
+  | 'other'
+  | 'not_applicable';
+type ExpectedContext = Readonly<{ method: ExpectedMethod; tool: ExpectedTool }>;
+type ExpectedFact =
+  | Readonly<{
+      kind: 'confirmation_decision';
+      feature: 'cost';
+      route: 'inline' | 'legacy' | 'bypass' | 'blocked';
+      reason:
+        | 'eligible'
+        | 'not_configured'
+        | 'capability_missing'
+        | 'read_only'
+        | 'zero_cost';
+    }>
+  | Readonly<{
+      kind: 'input_required';
+      feature: 'cost';
+      mode: 'form';
+      reason: 'initial' | 'missing_response' | 'changed_quote';
+    }>
+  | Readonly<{
+      kind: 'input_response';
+      feature: 'cost';
+      action: 'accept' | 'decline' | 'cancel';
+    }>
+  | Readonly<{
+      kind: 'resume_validation';
+      feature: 'cost';
+      result:
+        | 'valid'
+        | 'missing_response'
+        | 'tool_mismatch'
+        | 'arguments_mismatch'
+        | 'changed_quote';
+    }>
+  | Readonly<{ kind: 'operation'; feature: 'cost'; disposition: 'started' }>
+  | Readonly<{
+      kind: 'operation';
+      feature: 'cost';
+      disposition: 'returned' | 'threw';
+      durationMs: number;
+    }>;
+type ExpectedEnd = Readonly<{
+  result:
+    | 'completed'
+    | 'input_required'
+    | 'declined'
+    | 'cancelled'
+    | 'tool_error'
+    | 'handler_error';
+  durationMs: number;
+}>;
+type ExpectedObservation = Readonly<{
+  record(fact: ExpectedFact): void | Promise<void>;
+  end(result: ExpectedEnd): void | Promise<void>;
+}>;
+type ExpectedObserver = (
+  context: ExpectedContext
+) => ExpectedObservation | undefined;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B
+  ? 1
+  : 2
+  ? true
+  : false;
+type Assert<T extends true> = T;
+type ExpectedContract = [
+  ExpectedMethod,
+  ExpectedTool,
+  ExpectedContext,
+  'cost',
+  ExpectedFact,
+  ExpectedEnd,
+  ExpectedObservation,
+  ExpectedObserver,
+];
+type UtilsContract = [
+  Utils.ObservedMethod,
+  Utils.ObservedTool,
+  Utils.ObservationContext,
+  Utils.ConfirmationFeature,
+  Utils.ObservationFact,
+  Utils.ObservationEnd,
+  Utils.RequestObservation,
+  Utils.RequestObserver,
+];
+type SupabaseContract = [
+  Supabase.ObservedMethod,
+  Supabase.ObservedTool,
+  Supabase.ObservationContext,
+  Supabase.ConfirmationFeature,
+  Supabase.ObservationFact,
+  Supabase.ObservationEnd,
+  Supabase.RequestObservation,
+  Supabase.RequestObserver,
+];
+type ExactUtilsContract = Assert<Equal<UtilsContract, ExpectedContract>>;
+type ExactSupabaseContract = Assert<Equal<SupabaseContract, ExpectedContract>>;
+type ExactUtilsOption = Assert<
+  Equal<McpServerOptions['observer'], ExpectedObserver | undefined>
+>;
+type ExactSupabaseOption = Assert<
+  Equal<SupabaseMcpServerOptions['observer'], ExpectedObserver | undefined>
+>;
+type ExactRecorder = Assert<
+  Equal<
+    Parameters<Tool['execute']>[2],
+    ((fact: ExpectedFact) => void) | undefined
+  >
+>;
+
+const observer: Utils.RequestObserver = (context) => ({
+  record: async (fact) => {
+    void context.method;
+    void fact.kind;
+  },
+  end: (result) => {
+    void result.durationMs;
+  },
+});
+const observedTool = tool({
+  description: 'Public third-argument compatibility',
+  parameters: z.object({}),
+  outputSchema: z.object({ ok: z.boolean() }),
+  execute: async (_params, _context, record) => {
+    record?.({ kind: 'operation', feature: 'cost', disposition: 'started' });
+    return { ok: true };
+  },
+});
+// Existing one-/two-argument implementations remain assignable.
+const oneArgument: typeof observedTool.execute = async (_params) => ({
+  ok: true,
+});
+const twoArguments: typeof observedTool.execute = async (
+  _params,
+  _context
+) => ({ ok: true });
+void oneArgument;
+void twoArguments;
+const coreOptions: McpServerOptions = {
+  name: 'packed-observer',
+  version: '0.0.0',
+  observer,
+  tools: { observed: observedTool },
+};
+void createMcpServer(coreOptions);
 // A stubbed `account` platform, whose seven operations only ever run on a
 // tool call and so can reject here. It buys the thing that matters: asking
 // for the `account` feature group makes the server register real tools, so
@@ -20,7 +188,9 @@ const account: SupabaseMcpServerOptions['platform']['account'] = {
 const options: SupabaseMcpServerOptions = {
   platform: { account },
   features: ['account'],
+  observer,
 };
+void createSupabaseMcpServer(options);
 
 const handler = createSupabaseMcpHandler(options);
 


### PR DESCRIPTION
## Why

Let hosts observe Supabase cost-confirmation lifecycles without exposing payloads or changing tool results when an observer fails.

## What changed

Builds on the optional request observer in `@supabase/mcp-utils`, adding Supabase integration and built-in cost facts for account and branching tools. Observations describe cost-confirmation and operation behavior through bounded facts rather than raw arguments, results, state, or errors.

New tests are grouped into confirmation, operations, and isolation suites with a shared fixture. Pre-existing tests remain unchanged. Packed-consumer checks exercise the public package boundary, not only source imports.

## How to test

Run `CI=true pnpm test:packed-platform-consumer`. Expect 3 passing checks covering paid PROJECT confirmation issuance, acceptance and decline, plus observer-factory and sink failures. The checks verify bounded observations and unchanged results through the packed package's CJS, ESM, and NodeNext consumers.

## Trade-offs

This PR depends on the request-observation API in the preceding PR. Hosts still own collection, and synchronous observers can block. Handler duration excludes human wait and transport.

SQL and URL observations remain documentation-only future work. This does not add H1 or host collection, and the packed checks do not establish branch or cancellation coverage.
